### PR TITLE
Disable like button during loading

### DIFF
--- a/src/components/Likes/LikeButton.tsx
+++ b/src/components/Likes/LikeButton.tsx
@@ -23,8 +23,8 @@ interface Props {
 const LikeButton = ({ postId, motionId, commentId }: Props) => {
   const currentUser = useCurrentUser();
   const [likes, setLikes] = useState<Like[]>([]);
-  const [createLike] = useMutation(CREATE_LIKE);
-  const [deleteLike] = useMutation(DELETE_LIKE);
+  const [createLike, { loading: createLikeLoading }] = useMutation(CREATE_LIKE);
+  const [deleteLike, { loading: deleteLikeLoading }] = useMutation(DELETE_LIKE);
   const [getLikesByPostId, likesByPostIdRes] = useLazyQuery(
     LIKES_BY_POST_ID,
     noCache
@@ -96,6 +96,7 @@ const LikeButton = ({ postId, motionId, commentId }: Props) => {
       onClick={() =>
         alreadyLike() ? deleteLikeMutation() : createLikeMutation()
       }
+      disabled={createLikeLoading || deleteLikeLoading}
     >
       <ThumbUp
         color="primary"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7988,10 +7988,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
-  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
+prettier@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
@@ -10301,6 +10301,11 @@ yargs@^16.0.3:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yarn@^1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Fixes #24 by using the loading boolean prop to disable the like button during creation and deletion of a like record