### PR TITLE
Pagination

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,6 @@
       "error",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
     ],
-
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/anchor-is-valid": [
       "error",
@@ -41,7 +40,13 @@
       }
     ],
     "no-extra-boolean-cast": "off",
-    "object-shorthand": ["error", "properties"]
+    "object-shorthand": ["error", "properties"],
+    "prefer-const": [
+      "error",
+      {
+        "destructuring": "all"
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/src/apollo/client/localState.ts
+++ b/src/apollo/client/localState.ts
@@ -2,12 +2,15 @@ import { makeVar } from "@apollo/client";
 import { Common } from "../../constants";
 import { setAuthToken } from "../../utils/auth";
 
-export const feedItemsVar = makeVar<FeedItem[]>([]);
 export const motionVar = makeVar<Motion | null>(null);
 export const votesVar = makeVar<Vote[]>([]);
 export const headerKeyVar = makeVar<string>("");
 export const breadcrumbsVar = makeVar<Breadcrumb[]>([]);
 export const toastVar = makeVar<ToastNotification | null>(null);
+export const feedVar = makeVar<FeedState>(Common.DEFAULT_FEED_STATE);
+export const paginationVar = makeVar<PaginationState>(
+  Common.DEFAULT_PAGINATION_STATE
+);
 
 export const defaults = {
   user: { isAuthenticated: false, __typename: Common.TypeNames.CurrentUser },

--- a/src/apollo/client/queries/group.ts
+++ b/src/apollo/client/queries/group.ts
@@ -29,14 +29,27 @@ export const GROUP_BY_NAME = gql`
 `;
 
 export const GROUP_FEED = gql`
-  query ($name: String!) {
-    groupFeed(name: $name) {
-      ... on Post {
-        ...FeedPost
+  query (
+    $name: String!
+    $currentPage: Int!
+    $pageSize: Int!
+    $itemType: String
+  ) {
+    groupFeed(
+      name: $name
+      currentPage: $currentPage
+      pageSize: $pageSize
+      itemType: $itemType
+    ) {
+      pagedItems {
+        ... on Post {
+          ...FeedPost
+        }
+        ... on Motion {
+          ...FeedMotion
+        }
       }
-      ... on Motion {
-        ...FeedMotion
-      }
+      totalItems
     }
   }
   ${FEED_POST}

--- a/src/apollo/client/queries/user.ts
+++ b/src/apollo/client/queries/user.ts
@@ -40,14 +40,17 @@ export const USERS = gql`
 `;
 
 export const HOME_FEED = gql`
-  query ($userId: ID) {
-    homeFeed(userId: $userId) {
-      ... on Post {
-        ...FeedPost
+  query ($userId: ID, $currentPage: Int!, $pageSize: Int!) {
+    homeFeed(userId: $userId, currentPage: $currentPage, pageSize: $pageSize) {
+      pagedItems {
+        ... on Post {
+          ...FeedPost
+        }
+        ... on Motion {
+          ...FeedMotion
+        }
       }
-      ... on Motion {
-        ...FeedMotion
-      }
+      totalItems
     }
   }
   ${FEED_POST}
@@ -55,14 +58,17 @@ export const HOME_FEED = gql`
 `;
 
 export const PROFILE_FEED = gql`
-  query ($name: String!) {
-    profileFeed(name: $name) {
-      ... on Post {
-        ...FeedPost
+  query ($name: String!, $currentPage: Int!, $pageSize: Int!) {
+    profileFeed(name: $name, currentPage: $currentPage, pageSize: $pageSize) {
+      pagedItems {
+        ... on Post {
+          ...FeedPost
+        }
+        ... on Motion {
+          ...FeedMotion
+        }
       }
-      ... on Motion {
-        ...FeedMotion
-      }
+      totalItems
     }
   }
   ${FEED_POST}

--- a/src/apollo/typeDefs/index.ts
+++ b/src/apollo/typeDefs/index.ts
@@ -37,12 +37,17 @@ export const typeDefs = gql`
 
   union FeedItem = Post | Motion
 
+  type FeedPayload {
+    pagedItems: [FeedItem]
+    totalItems: Int!
+  }
+
   type Query {
     user(id: ID!): User!
     userByName(name: String!): User!
     allUsers: [User]!
-    homeFeed(userId: ID): [FeedItem]
-    profileFeed(name: String!): [FeedItem]
+    homeFeed(userId: ID, currentPage: Int!, pageSize: Int!): FeedPayload!
+    profileFeed(name: String!, currentPage: Int!, pageSize: Int!): FeedPayload!
 
     userFollowers(userId: ID!): [Follow]!
     userFollowersByName(name: String!): [Follow]!
@@ -71,7 +76,12 @@ export const typeDefs = gql`
     group(id: ID!): Group!
     groupByName(name: String!): Group!
     allGroups: [Group]!
-    groupFeed(name: String!): [FeedItem]
+    groupFeed(
+      name: String!
+      currentPage: Int!
+      pageSize: Int!
+      itemType: String
+    ): FeedPayload!
 
     groupMembers(groupId: ID!): [GroupMember]
     memberRequests(groupId: ID!): [MemberRequest]

--- a/src/components/Groups/ToggleForms.tsx
+++ b/src/components/Groups/ToggleForms.tsx
@@ -21,20 +21,10 @@ const StyledToggleButtonGroup = withStyles(() => ({
 }))(ToggleButtonGroup);
 
 interface Props {
-  posts: Post[];
-  motions: Motion[];
-  setPosts: (posts: Post[]) => void;
-  setMotions: (motions: Motion[]) => void;
   group: Group;
 }
 
-const ToggleForms = ({
-  posts,
-  motions,
-  setMotions,
-  setPosts,
-  group,
-}: Props) => {
+const ToggleForms = ({ group }: Props) => {
   const [toggle, setToggle] = useState<string>(Common.ModelNames.Post);
 
   const handleToggle = (
@@ -70,12 +60,8 @@ const ToggleForms = ({
         </StyledToggleButtonGroup>
       </div>
 
-      {toggle === Common.ModelNames.Post && (
-        <PostsForm posts={posts} setPosts={setPosts} group={group} />
-      )}
-      {toggle === Common.ModelNames.Motion && (
-        <MotionsForm motions={motions} setMotions={setMotions} group={group} />
-      )}
+      {toggle === Common.ModelNames.Post && <PostsForm group={group} />}
+      {toggle === Common.ModelNames.Motion && <MotionsForm group={group} />}
     </>
   );
 };

--- a/src/components/Shared/Feed.tsx
+++ b/src/components/Shared/Feed.tsx
@@ -1,8 +1,8 @@
-import { useReactiveVar } from "@apollo/client";
-import { CircularProgress } from "@material-ui/core";
 import { useEffect, useState } from "react";
+import { useReactiveVar } from "@apollo/client";
+import { Card, LinearProgress } from "@material-ui/core";
 
-import { feedItemsVar } from "../../apollo/client/localState";
+import { feedVar } from "../../apollo/client/localState";
 import { Common } from "../../constants";
 import Motion from "../Motions/Motion";
 import Post from "../Posts/Post";
@@ -10,46 +10,48 @@ import Post from "../Posts/Post";
 interface Props {
   deleteMotion: (id: string) => void;
   deletePost: (id: string) => void;
-  loading?: boolean;
 }
 
-const List = ({ deleteMotion, deletePost, loading }: Props) => {
-  const feed = useReactiveVar(feedItemsVar);
+const List = ({ deleteMotion, deletePost }: Props) => {
+  const { items, loading: feedLoading } = useReactiveVar(feedVar);
   /* TODO: Move this long comment to documentation
    Makes sure component is completely mounted and all matching html tags are present
    before adding additional components inside. Otherwise closing tags can be missed
    and classes incorrectly assigned to wrong HTML elements */
   const [mounted, setMounted] = useState(false);
+
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  if (!loading)
+  if (!mounted) return <></>;
+
+  if (feedLoading)
     return (
-      <>
-        {feed
-          .sort((a, b) => parseInt(b.createdAt) - parseInt(a.createdAt))
-          .slice(0, Common.PAGE_SIZE)
-          .map((item) => {
-            return item.__typename === Common.TypeNames.Motion ? (
-              <Motion
-                motion={item as Motion}
-                deleteMotion={deleteMotion}
-                key={`motion-${item.id}`}
-              />
-            ) : (
-              <Post
-                post={item as Post}
-                deletePost={deletePost}
-                key={`post-${item.id}`}
-              />
-            );
-          })}
-      </>
+      <Card>
+        <LinearProgress />
+      </Card>
     );
 
-  if (mounted) return <CircularProgress />;
-  return <></>;
+  return (
+    <>
+      {items.map((item) => {
+        return item.__typename === Common.TypeNames.Motion ? (
+          <Motion
+            motion={item as Motion}
+            deleteMotion={deleteMotion}
+            key={`motion-${item.id}`}
+          />
+        ) : (
+          <Post
+            post={item as Post}
+            deletePost={deletePost}
+            key={`post-${item.id}`}
+          />
+        );
+      })}
+    </>
+  );
 };
 
 export default List;

--- a/src/components/Shared/Pagination.tsx
+++ b/src/components/Shared/Pagination.tsx
@@ -1,0 +1,189 @@
+// This component was built before we were aware of the MUI TablePagination component: https://material-ui.com/components/pagination/#table-pagination
+// Please migrate to MUIs pagination component if this component gives any serious issues going forward.
+
+import { useReactiveVar } from "@apollo/client";
+import { useEffect, useState } from "react";
+import {
+  IconButton,
+  Typography,
+  makeStyles,
+  Theme,
+  createStyles,
+  Select,
+  MenuItem,
+} from "@material-ui/core";
+import { NavigateNext, NavigateBefore } from "@material-ui/icons";
+
+import { paginationVar, feedVar } from "../../apollo/client/localState";
+import styles from "../../styles/Shared/Pagination.module.scss";
+import Messages from "../../utils/messages";
+import { Common } from "../../constants";
+
+const useStyles = makeStyles((theme: Theme) => {
+  const hideForMobile = {
+    [theme.breakpoints.down(Common.DESKTOP_BREAKPOINT)]: {
+      display: "none",
+    },
+  };
+  const contrastColor = {
+    color: theme.palette.primary.contrastText,
+  };
+
+  return createStyles({
+    root: hideForMobile,
+    select: contrastColor,
+    icon: {
+      ...contrastColor,
+      ...hideForMobile,
+    },
+  });
+});
+
+interface Props {
+  bottom?: boolean;
+}
+
+const PageButtons = ({ bottom }: Props) => {
+  const paginationState = useReactiveVar(paginationVar);
+  const { totalItems, loading: feedLoading } = useReactiveVar(feedVar);
+  const { currentPage, pageSize } = paginationState;
+  const [selectOpen, setSelectOpen] = useState<boolean>(false);
+  const classes = useStyles();
+
+  useEffect(() => {
+    return () => {
+      paginationVar(Common.DEFAULT_PAGINATION_STATE);
+    };
+  }, []);
+
+  const handleButtonClick = (next = true) => {
+    const totalPages = Math.ceil(totalItems / pageSize);
+    const newCurrentPage = next ? currentPage + 1 : currentPage - 1;
+    const canTurnPage =
+      (!next && currentPage > 0) || (next && currentPage < totalPages - 1);
+
+    if (canTurnPage)
+      paginationVar({
+        ...paginationState,
+        currentPage: newCurrentPage,
+      });
+  };
+
+  const handlePageSizeChange = (
+    event: React.ChangeEvent<{ value: unknown }>
+  ) => {
+    paginationVar({
+      ...paginationState,
+      pageSize: parseInt(event.target.value as string),
+      currentPage: 0,
+    });
+  };
+
+  const sequenceText = (): string => {
+    if (feedLoading) return Messages.states.loading();
+    if (!totalItems) return "";
+
+    const start = currentPage * pageSize + 1;
+    let end = (currentPage + 1) * pageSize;
+    if (end > totalItems) end = totalItems;
+
+    return `${start}-${end} of ${totalItems}`;
+  };
+
+  const onFirstPage = (): boolean => {
+    return currentPage === 0;
+  };
+
+  const onLastPage = (): boolean => {
+    const totalPages = Math.ceil(totalItems / pageSize);
+    return currentPage === totalPages - 1;
+  };
+
+  const isDisabled = (next = true): boolean => {
+    if (feedLoading) return true;
+    if (next) return onLastPage();
+    return onFirstPage();
+  };
+
+  const isHiding = (): boolean => {
+    if (bottom && feedLoading) return true;
+    if (!feedLoading && !totalItems) return true;
+    return false;
+  };
+
+  if (isHiding()) return <></>;
+
+  return (
+    <div className={styles.container}>
+      <Typography
+        onClick={() => setSelectOpen(!selectOpen)}
+        className={styles.rowsPerPageText}
+        classes={{ root: classes.root }}
+        color="primary"
+      >
+        {Messages.pagination.rowsPerPage()}
+      </Typography>
+
+      <Select
+        value={pageSize}
+        onChange={handlePageSizeChange}
+        onClick={() => setSelectOpen(!selectOpen)}
+        classes={classes}
+        disableUnderline
+        open={selectOpen}
+      >
+        {[
+          Common.PageSizes.Min,
+          Common.PageSizes.Default,
+          Common.PageSizes.Max,
+        ].map((_pageSize) => (
+          <MenuItem value={_pageSize} key={_pageSize}>
+            {_pageSize}
+          </MenuItem>
+        ))}
+      </Select>
+
+      <Typography className={styles.sequenceText} color="primary">
+        {sequenceText()}
+      </Typography>
+
+      <IconButton
+        onClick={() => handleButtonClick(false)}
+        disabled={isDisabled(false)}
+        size="small"
+      >
+        <NavigateBefore
+          color={isDisabled(false) ? "disabled" : "primary"}
+          fontSize="large"
+        />
+      </IconButton>
+
+      <IconButton
+        onClick={() => handleButtonClick()}
+        disabled={isDisabled()}
+        size="small"
+      >
+        <NavigateNext
+          color={isDisabled() ? "disabled" : "primary"}
+          fontSize="large"
+        />
+      </IconButton>
+    </div>
+  );
+};
+
+interface PaginationProps {
+  children?: React.ReactChild;
+}
+
+const Pagination = ({ children }: PaginationProps) => {
+  return (
+    <>
+      <PageButtons />
+      {children}
+      <PageButtons bottom />
+    </>
+  );
+};
+
+export default Pagination;

--- a/src/components/_App/Layout.tsx
+++ b/src/components/_App/Layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import Head from "next/head";
 import { Container } from "@material-ui/core";
 import { ThemeProvider } from "@material-ui/core/styles";
@@ -8,7 +9,6 @@ import Messages from "../../utils/messages";
 import Breadcrumbs from "../Shared/Breadcrumbs";
 import Toast from "../Shared/Toast";
 import muiTheme from "../../styles/Shared/theme";
-import { useEffect, useState } from "react";
 
 interface Props {
   children: React.ReactChild;
@@ -20,25 +20,29 @@ const Layout = ({ children }: Props) => {
    before adding additional components inside. Otherwise closing tags can be missed
    and classes incorrectly assigned to wrong HTML elements */
   const [mounted, setMounted] = useState(false);
+
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  if (mounted) return (
-    <ThemeProvider theme={muiTheme}>
-      <Head>
-        <HeadContent />
-        <title>{Messages.brand()}</title>
-      </Head>
-      <Header />
-      <Container maxWidth="sm">
-        <Breadcrumbs />
-        {children}
-        <Toast />
-      </Container>
-    </ThemeProvider>
+  return (
+    <>
+      {mounted && (
+        <ThemeProvider theme={muiTheme}>
+          <Head>
+            <HeadContent />
+            <title>{Messages.brand()}</title>
+          </Head>
+          <Header />
+          <Container maxWidth="sm">
+            <Breadcrumbs />
+            {children}
+            <Toast />
+          </Container>
+        </ThemeProvider>
+      )}
+    </>
   );
-  return <></>
 };
 
 export default Layout;

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,5 +1,4 @@
 export namespace Common {
-  export const PAGE_SIZE = 10;
   export const EXPIRES_IN = "90d";
   export const DESKTOP_BREAKPOINT = 850;
 
@@ -66,4 +65,21 @@ export namespace Common {
     Info = "info",
     Warning = "warning",
   }
+
+  export enum PageSizes {
+    Min = 5,
+    Max = 20,
+    Default = 10,
+  }
+
+  export const DEFAULT_PAGINATION_STATE: PaginationState = {
+    currentPage: 0,
+    pageSize: PageSizes.Default,
+  };
+
+  export const DEFAULT_FEED_STATE: FeedState = {
+    items: [],
+    totalItems: 0,
+    loading: false,
+  };
 }

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -4,9 +4,9 @@ export const useWindowSize = () => {
   const [size, setSize] = useState([0, 0]);
 
   useEffect(() => {
-    function updateSize() {
+    const updateSize = () => {
       setSize([window.innerWidth, window.innerHeight]);
-    }
+    };
     updateSize();
     window.addEventListener("resize", updateSize);
     return () => window.removeEventListener("resize", updateSize);

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -320,6 +320,10 @@ const en = {
     notFound: (itemType: string) => `${itemType} not found.`,
   },
 
+  pagination: {
+    rowsPerPage: () => "Rows per page: ",
+  },
+
   time: {
     now: () => "now",
     minutes: (minutes: number) => `${minutes}m`,

--- a/src/pages/groups/[name].tsx
+++ b/src/pages/groups/[name].tsx
@@ -1,34 +1,35 @@
 import { useState, useEffect } from "react";
-import { useLazyQuery, useMutation } from "@apollo/client";
+import { useLazyQuery, useMutation, useReactiveVar } from "@apollo/client";
 import Router, { useRouter } from "next/router";
 import { Tab, Tabs, Card, CircularProgress } from "@material-ui/core";
 
 import Group from "../../components/Groups/Group";
-import PostsList from "../../components/Posts/List";
-import MotionsList from "../../components/Motions/List";
 import Feed from "../../components/Shared/Feed";
 import PostsForm from "../../components/Posts/Form";
 import MotionsForm from "../../components/Motions/Form";
 import ToggleForms from "../../components/Groups/ToggleForms";
+import Pagination from "../../components/Shared/Pagination";
 import { GROUP_BY_NAME, GROUP_FEED } from "../../apollo/client/queries";
 import {
   DELETE_GROUP,
   DELETE_POST,
   DELETE_MOTION,
 } from "../../apollo/client/mutations";
-import { feedItemsVar } from "../../apollo/client/localState";
+import { feedVar, paginationVar } from "../../apollo/client/localState";
 import { Common } from "../../constants";
 import Messages from "../../utils/messages";
 import { noCache } from "../../utils/apollo";
 import { useCurrentUser, useMembersByGroupId } from "../../hooks";
+import { resetFeed } from "../../utils/items";
 
 const Show = () => {
-  const { query } = useRouter();
+  const {
+    query: { name },
+  } = useRouter();
   const currentUser = useCurrentUser();
+  const feed = useReactiveVar(feedVar);
+  const { currentPage, pageSize } = useReactiveVar(paginationVar);
   const [group, setGroup] = useState<Group>();
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [motions, setMotions] = useState<Motion[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
   const [tab, setTab] = useState<number>(0);
   const [groupMembers] = useMembersByGroupId(group?.id);
   const [getGroupRes, groupRes] = useLazyQuery(GROUP_BY_NAME, noCache);
@@ -38,45 +39,54 @@ const Show = () => {
   const [deletePost] = useMutation(DELETE_POST);
 
   useEffect(() => {
-    const vars = {
-      variables: { name: query.name },
-    };
-    if (query.name) {
-      getGroupRes(vars);
-      getFeedRes(vars);
+    if (name) {
+      getGroupRes({
+        variables: { name },
+      });
     }
-  }, [query.name]);
+  }, [name]);
 
   useEffect(() => {
     if (groupRes.data) setGroup(groupRes.data.groupByName);
   }, [groupRes.data]);
 
   useEffect(() => {
-    if (feedRes.data) {
-      feedItemsVar(feedRes.data.groupFeed);
-      setPosts(
-        feedRes.data.groupFeed.filter(
-          (item: FeedItem) => item.__typename === Common.TypeNames.Post
-        )
-      );
-      setMotions(
-        feedRes.data.groupFeed.filter(
-          (item: FeedItem) => item.__typename === Common.TypeNames.Motion
-        )
-      );
-      setLoading(false);
+    if (name) {
+      let itemType = "";
+      if (tab === 1) itemType = Common.ModelNames.Motion;
+      else if (tab === 2) itemType = Common.ModelNames.Post;
+
+      feedVar({
+        ...feed,
+        loading: true,
+      });
+
+      getFeedRes({
+        variables: {
+          name,
+          pageSize,
+          currentPage,
+          itemType,
+        },
+      });
     }
-    return () => {
-      feedItemsVar([]);
-    };
+  }, [name, currentPage, pageSize, tab]);
+
+  useEffect(() => {
+    if (feedRes.data) {
+      feedVar({
+        items: feedRes.data.groupFeed.pagedItems,
+        totalItems: feedRes.data.groupFeed.totalItems,
+        loading: feedRes.loading,
+      });
+    }
   }, [feedRes.data]);
 
   useEffect(() => {
-    feedItemsVar([...posts, ...motions]);
     return () => {
-      feedItemsVar([]);
+      resetFeed();
     };
-  }, [posts, motions]);
+  }, []);
 
   const deleteGroupHandler = async (groupId: string) => {
     await deleteGroup({
@@ -93,7 +103,14 @@ const Show = () => {
         id,
       },
     });
-    setPosts(posts.filter((post: Post) => post.id !== id));
+    feedVar({
+      ...feed,
+      items: feed.items.filter(
+        (item: FeedItem) =>
+          item.id !== id || item.__typename !== Common.TypeNames.Post
+      ),
+      totalItems: feed.totalItems - 1,
+    });
   };
 
   const deleteMotionHandler = async (id: string) => {
@@ -102,7 +119,14 @@ const Show = () => {
         id,
       },
     });
-    setMotions(motions.filter((motion: Motion) => motion.id !== id));
+    feedVar({
+      ...feed,
+      items: feed.items.filter(
+        (item: FeedItem) =>
+          item.id !== id || item.__typename !== Common.TypeNames.Motion
+      ),
+      totalItems: feed.totalItems - 1,
+    });
   };
 
   const inThisGroup = (): boolean => {
@@ -117,12 +141,12 @@ const Show = () => {
 
         <Card>
           <Tabs
-            textColor="inherit"
-            centered
             value={tab}
             onChange={(_event: React.ChangeEvent<any>, newValue: number) =>
               setTab(newValue)
             }
+            textColor="inherit"
+            centered
           >
             <Tab label={Messages.groups.tabs.all()} />
             <Tab label={Messages.groups.tabs.motions()} />
@@ -130,54 +154,20 @@ const Show = () => {
           </Tabs>
         </Card>
 
-        {tab === 0 && (
+        {inThisGroup() && (
           <>
-            {inThisGroup() && (
-              <ToggleForms
-                posts={posts}
-                motions={motions}
-                setPosts={setPosts}
-                setMotions={setMotions}
-                group={group}
-              />
-            )}
-            <Feed
-              deleteMotion={deleteMotionHandler}
-              deletePost={deletePostHandler}
-              loading={loading}
-            />
+            {tab === 0 && <ToggleForms group={group} />}
+            {tab === 1 && <MotionsForm group={group} />}
+            {tab === 2 && <PostsForm group={group} />}
           </>
         )}
 
-        {tab === 1 && (
-          <>
-            {inThisGroup() && (
-              <MotionsForm
-                motions={motions}
-                setMotions={setMotions}
-                group={group}
-              />
-            )}
-            <MotionsList
-              motions={motions}
-              loading={loading}
-              deleteMotion={deleteMotionHandler}
-            />
-          </>
-        )}
-
-        {tab === 2 && (
-          <>
-            {inThisGroup() && (
-              <PostsForm posts={posts} setPosts={setPosts} group={group} />
-            )}
-            <PostsList
-              posts={posts}
-              loading={loading}
-              deletePost={deletePostHandler}
-            />
-          </>
-        )}
+        <Pagination>
+          <Feed
+            deleteMotion={deleteMotionHandler}
+            deletePost={deletePostHandler}
+          />
+        </Pagination>
       </>
     );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useQuery, useMutation, useReactiveVar } from "@apollo/client";
+import { useMutation, useReactiveVar, useLazyQuery } from "@apollo/client";
 
 import PostForm from "../components/Posts/Form";
 import Feed from "../components/Shared/Feed";
@@ -7,27 +7,47 @@ import { HOME_FEED } from "../apollo/client/queries";
 import { DELETE_POST, DELETE_MOTION } from "../apollo/client/mutations";
 import WelcomeCard from "../components/About/Welcome";
 import { Common } from "../constants";
-import { feedItemsVar } from "../apollo/client/localState";
+import { feedVar, paginationVar } from "../apollo/client/localState";
 import { useCurrentUser } from "../hooks";
-import { noCache } from "../utils/apollo";
+import { noCache, resetFeed } from "../utils/clientIndex";
+import Pagination from "../components/Shared/Pagination";
 
 const Home = () => {
   const currentUser = useCurrentUser();
-  const feed = useReactiveVar(feedItemsVar);
+  const feed = useReactiveVar(feedVar);
+  const { currentPage, pageSize } = useReactiveVar(paginationVar);
   const [deleteMotion] = useMutation(DELETE_MOTION);
   const [deletePost] = useMutation(DELETE_POST);
-  const feedRes = useQuery(HOME_FEED, {
-    variables: {
-      userId: currentUser?.id,
-    },
-    ...noCache,
-  });
+  const [getFeedRes, feedRes] = useLazyQuery(HOME_FEED, noCache);
 
   useEffect(() => {
-    if (feedRes.data) feedItemsVar(feedRes.data.homeFeed);
     return () => {
-      feedItemsVar([]);
+      resetFeed();
     };
+  }, []);
+
+  useEffect(() => {
+    getFeedRes({
+      variables: {
+        userId: currentUser?.id,
+        currentPage,
+        pageSize,
+      },
+    });
+
+    feedVar({
+      ...feed,
+      loading: true,
+    });
+  }, [currentUser, currentPage, pageSize]);
+
+  useEffect(() => {
+    if (feedRes.data)
+      feedVar({
+        items: feedRes.data.homeFeed.pagedItems,
+        totalItems: feedRes.data.homeFeed.totalItems,
+        loading: feedRes.loading,
+      });
   }, [feedRes.data]);
 
   const deletePostHandler = async (id: string) => {
@@ -36,12 +56,14 @@ const Home = () => {
         id,
       },
     });
-    feedItemsVar(
-      feed.filter(
-        (post: FeedItem) =>
-          post.id !== id || post.__typename !== Common.TypeNames.Post
-      )
-    );
+    feedVar({
+      ...feed,
+      items: feed.items.filter(
+        (item: FeedItem) =>
+          item.id !== id || item.__typename !== Common.TypeNames.Post
+      ),
+      totalItems: feed.totalItems - 1,
+    });
   };
 
   const deleteMotionHandler = async (id: string) => {
@@ -50,25 +72,28 @@ const Home = () => {
         id,
       },
     });
-    feedItemsVar(
-      feed.filter(
-        (motion: FeedItem) =>
-          motion.id !== id || motion.__typename !== Common.TypeNames.Motion
-      )
-    );
+    feedVar({
+      ...feed,
+      items: feed.items.filter(
+        (item: FeedItem) =>
+          item.id !== id || item.__typename !== Common.TypeNames.Motion
+      ),
+      totalItems: feed.totalItems - 1,
+    });
   };
 
   return (
     <>
       <WelcomeCard isLoggedIn={!!currentUser} />
 
-      {currentUser && <PostForm posts={feed} setPosts={feedItemsVar} />}
+      {currentUser && <PostForm posts={feed.items} />}
 
-      <Feed
-        deletePost={deletePostHandler}
-        deleteMotion={deleteMotionHandler}
-        loading={feedRes.loading}
-      />
+      <Pagination>
+        <Feed
+          deletePost={deletePostHandler}
+          deleteMotion={deleteMotionHandler}
+        />
+      </Pagination>
     </>
   );
 };

--- a/src/pages/users/[name].tsx
+++ b/src/pages/users/[name].tsx
@@ -5,6 +5,7 @@ import { CircularProgress } from "@material-ui/core";
 
 import User from "../../components/Users/User";
 import Feed from "../../components/Shared/Feed";
+import Pagination from "../../components/Shared/Pagination";
 import { USER_BY_NAME, PROFILE_FEED } from "../../apollo/client/queries";
 import {
   DELETE_USER,
@@ -12,17 +13,20 @@ import {
   DELETE_MOTION,
   LOGOUT_USER,
 } from "../../apollo/client/mutations";
-import { feedItemsVar } from "../../apollo/client/localState";
+import { feedVar, paginationVar } from "../../apollo/client/localState";
 import { Common } from "../../constants";
 import { useCurrentUser } from "../../hooks";
 import { noCache } from "../../utils/apollo";
+import { resetFeed } from "../../utils/clientIndex";
 
 const Show = () => {
-  const { query } = useRouter();
+  const {
+    query: { name },
+  } = useRouter();
   const currentUser = useCurrentUser();
-  const feed = useReactiveVar(feedItemsVar);
+  const feed = useReactiveVar(feedVar);
+  const { currentPage, pageSize } = useReactiveVar(paginationVar);
   const [user, setUser] = useState<User>();
-  const [loadingFeed, setLoadingFeed] = useState<boolean>(true);
   const [getUserRes, userRes] = useLazyQuery(USER_BY_NAME);
   const [getFeedRes, feedRes] = useLazyQuery(PROFILE_FEED, noCache);
   const [deleteUser] = useMutation(DELETE_USER);
@@ -31,24 +35,47 @@ const Show = () => {
   const [logoutUser] = useMutation(LOGOUT_USER);
 
   useEffect(() => {
-    const vars = {
-      variables: { name: query.name },
+    return () => {
+      resetFeed();
     };
-    if (query.name) {
-      getUserRes(vars);
-      getFeedRes(vars);
+  }, []);
+
+  useEffect(() => {
+    if (name) {
+      getUserRes({
+        variables: { name },
+      });
     }
-  }, [query.name]);
+  }, [name]);
+
+  useEffect(() => {
+    if (name) {
+      getFeedRes({
+        variables: {
+          name,
+          pageSize,
+          currentPage,
+        },
+      });
+
+      feedVar({
+        ...feed,
+        loading: true,
+      });
+    }
+  }, [name, currentPage, pageSize]);
 
   useEffect(() => {
     if (userRes.data) setUser(userRes.data.userByName);
   }, [userRes.data]);
 
   useEffect(() => {
-    if (feedRes.data) {
-      feedItemsVar(feedRes.data.profileFeed);
-      setLoadingFeed(false);
-    }
+    if (feedRes.data)
+      feedVar({
+        items: feedRes.data.profileFeed.pagedItems,
+        totalItems: feedRes.data.profileFeed.totalItems,
+        loading: feedRes.loading,
+      });
   }, [feedRes.data]);
 
   const deleteUserHandler = async (userId: string) => {
@@ -69,12 +96,14 @@ const Show = () => {
         id,
       },
     });
-    feedItemsVar(
-      feed.filter(
-        (post: FeedItem) =>
-          post.id !== id || post.__typename !== Common.TypeNames.Post
-      )
-    );
+    if (feed)
+      feedVar({
+        ...feed,
+        items: feed.items.filter(
+          (item: FeedItem) =>
+            item.id !== id || item.__typename !== Common.TypeNames.Post
+        ),
+      });
   };
 
   const deleteMotionHandler = async (id: string) => {
@@ -83,12 +112,14 @@ const Show = () => {
         id,
       },
     });
-    feedItemsVar(
-      feed.filter(
-        (motion: FeedItem) =>
-          motion.id !== id || motion.__typename !== Common.TypeNames.Motion
-      )
-    );
+    if (feed)
+      feedVar({
+        ...feed,
+        items: feed.items.filter(
+          (item: FeedItem) =>
+            item.id !== id || item.__typename !== Common.TypeNames.Motion
+        ),
+      });
   };
 
   const ownUser = (): boolean => {
@@ -101,11 +132,13 @@ const Show = () => {
       {user ? (
         <>
           <User user={user} deleteUser={deleteUserHandler} />
-          <Feed
-            loading={loadingFeed}
-            deleteMotion={deleteMotionHandler}
-            deletePost={deletePostHandler}
-          />
+
+          <Pagination>
+            <Feed
+              deleteMotion={deleteMotionHandler}
+              deletePost={deletePostHandler}
+            />
+          </Pagination>
         </>
       ) : (
         <CircularProgress />

--- a/src/pages/users/index.tsx
+++ b/src/pages/users/index.tsx
@@ -47,7 +47,7 @@ const Index = () => {
         {users
           .slice()
           .reverse()
-          .slice(0, Common.PAGE_SIZE)
+          .slice(0, Common.PageSizes.Default)
           .map((user: User) => {
             return (
               <User user={user} deleteUser={deleteUserHandler} key={user.id} />

--- a/src/styles/Shared/Header.module.scss
+++ b/src/styles/Shared/Header.module.scss
@@ -1,7 +1,5 @@
 @import "../Shared/Shared.module.scss";
 
-// top, right, bottom, left
-
 .navbar {
   background: $navbarGray;
   padding: 23px 22px;

--- a/src/styles/Shared/Pagination.module.scss
+++ b/src/styles/Shared/Pagination.module.scss
@@ -1,0 +1,23 @@
+@import "../Shared/Shared.module.scss";
+
+.container {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.text {
+  padding-top: 8px;
+  padding-right: 5px;
+}
+
+.rowsPerPageText {
+  @extend .text, .noSelect;
+  cursor: pointer;
+}
+
+.sequenceText {
+  @extend .text;
+  padding-left: 20px;
+}

--- a/src/styles/Shared/Shared.module.scss
+++ b/src/styles/Shared/Shared.module.scss
@@ -51,3 +51,5 @@ $desktopBreakpoint: 850px;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
 }
+
+// top, right, bottom, left

--- a/src/styles/Shared/globals.scss
+++ b/src/styles/Shared/globals.scss
@@ -49,3 +49,9 @@ a:hover {
 *:focus {
   outline: none !important;
 }
+
+// TODO: This should be removed after converting to Select component
+.MuiNativeSelect-select:not([multiple]) option {
+  background-color: $darkGray !important;
+  font-family: Helvetica !important;
+}

--- a/src/styles/Shared/theme.ts
+++ b/src/styles/Shared/theme.ts
@@ -51,6 +51,9 @@ const muiTheme = createTheme({
       colorPrimary: {
         color: globalTheme.palette.primary.contrastText,
       },
+      colorDisabled: {
+        color: "rgb(100, 100, 100)",
+      },
     },
 
     MuiInput: {

--- a/src/typings/common.d.ts
+++ b/src/typings/common.d.ts
@@ -1,6 +1,17 @@
 type FeedItem = Motion | Post;
 type BackendFeedItem = BackendMotion | BackendPost;
 
+interface FeedState {
+  items: FeedItem[];
+  totalItems: number;
+  loading: boolean;
+}
+
+interface PaginationState {
+  currentPage: number;
+  pageSize: number;
+}
+
 interface Breadcrumb {
   label: string;
   href?: string;

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -1,3 +1,6 @@
+import { feedVar } from "../apollo/client/localState";
+import { Common } from "../constants";
+
 export const displayName = (name: string): string => {
   let shownName = name[0].toUpperCase() + name.slice(1);
   shownName = shownName.replace(/-/g, " ");
@@ -7,4 +10,21 @@ export const displayName = (name: string): string => {
 export const pluralize = (size: number): string => {
   if (size === 0 || size > 1) return "s";
   return "";
+};
+
+export const paginate = (
+  totalItems: any[],
+  currentPage: number,
+  pageSize: number
+): any[] => {
+  let items = totalItems.reverse();
+
+  if (currentPage > 0)
+    items = items.slice(currentPage * pageSize, items.length);
+
+  return items.slice(0, pageSize);
+};
+
+export const resetFeed = (): void => {
+  feedVar(Common.DEFAULT_FEED_STATE);
 };


### PR DESCRIPTION
This PR implements basic functionality for pagination.

#### Changes
- Implemented pagination for the following
  - Home feed
  - Group feed
  - User profile feed
- Added the following
  - `Pagination` shared HOC
  - `paginate` util function
  - `paginationVar` in `localState`
  - `FeedState` interface
  - Constants for default feed and pagination state
- Resolved styling issues with `select` in Firefox

The following will need to be implemented in follow up PRs:
- Pagination for all other content feeds
- User settings to save Rows per page selection