### PR TITLE
Eliminate render errors causing Toast display issues/console errors

### DIFF
--- a/src/components/Shared/Feed.tsx
+++ b/src/components/Shared/Feed.tsx
@@ -1,5 +1,6 @@
 import { useReactiveVar } from "@apollo/client";
 import { CircularProgress } from "@material-ui/core";
+import { useEffect, useState } from "react";
 
 import { feedItemsVar } from "../../apollo/client/localState";
 import { Common } from "../../constants";
@@ -14,6 +15,14 @@ interface Props {
 
 const List = ({ deleteMotion, deletePost, loading }: Props) => {
   const feed = useReactiveVar(feedItemsVar);
+  /* TODO: Move this long comment to documentation
+   Makes sure component is completely mounted and all matching html tags are present
+   before adding additional components inside. Otherwise closing tags can be missed
+   and classes incorrectly assigned to wrong HTML elements */
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   if (!loading)
     return (
@@ -39,7 +48,8 @@ const List = ({ deleteMotion, deletePost, loading }: Props) => {
       </>
     );
 
-  return <CircularProgress />;
+  if (mounted) return <CircularProgress />;
+  return <></>;
 };
 
 export default List;

--- a/src/components/_App/Layout.tsx
+++ b/src/components/_App/Layout.tsx
@@ -8,13 +8,23 @@ import Messages from "../../utils/messages";
 import Breadcrumbs from "../Shared/Breadcrumbs";
 import Toast from "../Shared/Toast";
 import muiTheme from "../../styles/Shared/theme";
+import { useEffect, useState } from "react";
 
 interface Props {
   children: React.ReactChild;
 }
 
 const Layout = ({ children }: Props) => {
-  return (
+  /* TODO: Move this long comment to documentation
+  Makes sure component is completely mounted and all matching html tags are present
+   before adding additional components inside. Otherwise closing tags can be missed
+   and classes incorrectly assigned to wrong HTML elements */
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (mounted) return (
     <ThemeProvider theme={muiTheme}>
       <Head>
         <HeadContent />
@@ -28,6 +38,7 @@ const Layout = ({ children }: Props) => {
       </Container>
     </ThemeProvider>
   );
+  return <></>
 };
 
 export default Layout;


### PR DESCRIPTION
[Implemented Solution](https://github.com/vercel/next.js/discussions/17443#discussioncomment-637879)

Adopted this fix for console errors being thrown to warn of render mismatch between server and client. Essentially, certain html tags were missing from the final render causing class styles to be assigned incorrectly. Which is how Toast ended up inside a CircularProgress root, causing spinning Toast messages.

This fix was adopted in the Feed and Layout components eliminating several console errors in addition to the actual render errors.

While I added block comments this needs to be properly documented #11