### PR TITLE
Replace all NativeSelect with Select (MUI)

### DIFF
--- a/src/components/Motions/Form.tsx
+++ b/src/components/Motions/Form.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from "react";
 import { useLazyQuery, useMutation, useReactiveVar } from "@apollo/client";
 import {
   FormGroup,
-  NativeSelect,
   FormControl,
   InputLabel,
+  MenuItem,
 } from "@material-ui/core";
 import Router from "next/router";
 import { Formik, FormikHelpers, Form, Field, FormikProps } from "formik";
@@ -27,6 +27,7 @@ import SubmitButton from "../Shared/SubmitButton";
 import TextField from "../Shared/TextField";
 import SelectedImages from "../Shared/SelectedImages";
 import ImageInput from "../Shared/ImageInput";
+import Dropdown from "../Shared/Dropdown";
 
 interface FormikValues {
   body: string;
@@ -127,8 +128,8 @@ const MotionsForm = ({
     }
   };
 
-  const handleActionChange = (event: React.ChangeEvent<{ value: string }>) => {
-    setAction(event.target.value);
+  const handleActionChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setAction(event.target.value as string);
   };
 
   const deleteImageHandler = async (id: string) => {
@@ -183,32 +184,31 @@ const MotionsForm = ({
               }
               component={TextField}
               multiline
-              style={{ marginBottom: 0 }}
+              style={{ marginBottom: 3 }}
             />
 
-            <FormControl style={{ marginBottom: "18px" }}>
+            <FormControl style={{ marginBottom: 18 }}>
               <InputLabel>{Messages.motions.form.motionType()}</InputLabel>
-              <NativeSelect value={action} onChange={handleActionChange}>
-                <option aria-label={Messages.forms.none()} value="" />
-                <option value={Motions.ActionTypes.PlanEvent}>
+              <Dropdown value={action} onChange={handleActionChange}>
+                <MenuItem value={Motions.ActionTypes.PlanEvent}>
                   {Messages.motions.form.actionTypes.planEvent()}
-                </option>
-                <option value={Motions.ActionTypes.ChangeName}>
+                </MenuItem>
+                <MenuItem value={Motions.ActionTypes.ChangeName}>
                   {Messages.motions.form.actionTypes.changeName()}
-                </option>
-                <option value={Motions.ActionTypes.ChangeDescription}>
+                </MenuItem>
+                <MenuItem value={Motions.ActionTypes.ChangeDescription}>
                   {Messages.motions.form.actionTypes.changeDescription()}
-                </option>
-                <option value={Motions.ActionTypes.ChangeImage}>
+                </MenuItem>
+                <MenuItem value={Motions.ActionTypes.ChangeImage}>
                   {Messages.motions.form.actionTypes.changeImage()}
-                </option>
-                <option value={Motions.ActionTypes.ChangeSettings}>
+                </MenuItem>
+                <MenuItem value={Motions.ActionTypes.ChangeSettings}>
                   {Messages.motions.form.actionTypes.changeSettings()}
-                </option>
-                <option value={Motions.ActionTypes.Test}>
+                </MenuItem>
+                <MenuItem value={Motions.ActionTypes.Test}>
                   {Messages.motions.form.actionTypes.test()}
-                </option>
-              </NativeSelect>
+                </MenuItem>
+              </Dropdown>
             </FormControl>
 
             <ActionFields actionType={action} setActionData={setActionData} />

--- a/src/components/ServerInvites/Form.tsx
+++ b/src/components/ServerInvites/Form.tsx
@@ -4,7 +4,7 @@ import {
   FormControl,
   FormGroup,
   InputLabel,
-  NativeSelect,
+  MenuItem,
 } from "@material-ui/core";
 
 import { CREATE_SERVER_INVITE } from "../../apollo/client/mutations";
@@ -14,6 +14,7 @@ import { useCurrentUser } from "../../hooks";
 import { Common } from "../../constants";
 import { ServerInvites } from "../../constants";
 import SubmitButton from "../Shared/SubmitButton";
+import Dropdown from "../Shared/Dropdown";
 
 interface Props {
   invites: ServerInvite[];
@@ -51,13 +52,15 @@ const ServerInviteForm = ({ invites, setInvites }: Props) => {
   };
 
   const handleExpiresAtChange = (
-    event: React.ChangeEvent<{ value: string }>
+    event: React.ChangeEvent<{ value: unknown }>
   ) => {
-    setExpiresAt(event.target.value);
+    setExpiresAt((event.target.value as number).toString());
   };
 
-  const handleMaxUsesChange = (event: React.ChangeEvent<{ value: string }>) => {
-    setMaxUses(event.target.value);
+  const handleMaxUsesChange = (
+    event: React.ChangeEvent<{ value: unknown }>
+  ) => {
+    setMaxUses(event.target.value as string);
   };
 
   if (currentUser)
@@ -66,38 +69,36 @@ const ServerInviteForm = ({ invites, setInvites }: Props) => {
         <FormGroup style={{ marginBottom: "12px" }}>
           <FormControl>
             <InputLabel>{Messages.invites.form.labels.expiresAt()}</InputLabel>
-            <NativeSelect value={expiresAt} onChange={handleExpiresAtChange}>
-              <option aria-label={Messages.forms.none()} value="" />
-              <option value={Common.Time.Day}>
+            <Dropdown value={expiresAt} onChange={handleExpiresAtChange}>
+              <MenuItem value={Common.Time.Day}>
                 {Messages.invites.form.expiresAtOptions.oneDay()}
-              </option>
-              <option value={Common.Time.Week}>
+              </MenuItem>
+              <MenuItem value={Common.Time.Week}>
                 {Messages.invites.form.expiresAtOptions.sevenDays()}
-              </option>
-              <option value={Common.Time.Month}>
+              </MenuItem>
+              <MenuItem value={Common.Time.Month}>
                 {Messages.invites.form.expiresAtOptions.oneMonth()}
-              </option>
-              <option value={undefined}>
+              </MenuItem>
+              <MenuItem value={""}>
                 {Messages.invites.form.expiresAtOptions.never()}
-              </option>
-            </NativeSelect>
+              </MenuItem>
+            </Dropdown>
           </FormControl>
 
           <FormControl>
             <InputLabel>{Messages.invites.form.labels.maxUses()}</InputLabel>
-            <NativeSelect value={maxUses} onChange={handleMaxUsesChange}>
-              <option aria-label={Messages.forms.none()} value="" />
-              <option value={undefined}>
-                {Messages.invites.form.maxUsesOptions.noLimit()}
-              </option>
-              {ServerInvites.MAX_USES_OPTIONS.map((option) => {
+            <Dropdown value={maxUses} onChange={handleMaxUsesChange}>
+              {ServerInvites.MAX_USES_OPTIONS.map((option: number) => {
                 return (
-                  <option value={option} key={option}>
+                  <MenuItem value={option} key={option}>
                     {Messages.invites.form.maxUsesOptions.xUses(option)}
-                  </option>
+                  </MenuItem>
                 );
               })}
-            </NativeSelect>
+              <MenuItem value={""}>
+                {Messages.invites.form.maxUsesOptions.noLimit()}
+              </MenuItem>
+            </Dropdown>
           </FormControl>
         </FormGroup>
 

--- a/src/components/Settings/Form.tsx
+++ b/src/components/Settings/Form.tsx
@@ -4,7 +4,7 @@ import { useMutation } from "@apollo/client";
 import {
   FormGroup,
   Switch,
-  NativeSelect,
+  MenuItem,
   Grid,
   Slider,
   Input,
@@ -18,6 +18,7 @@ import Messages from "../../utils/messages";
 import { useCurrentUser } from "../../hooks";
 import { displayName } from "../../utils/items";
 import SubmitButton from "../Shared/SubmitButton";
+import Dropdown from "../Shared/Dropdown";
 
 const NumberInput = ({
   value,
@@ -95,10 +96,10 @@ const SettingsForm = ({
   };
 
   const handleSettingChange = (
-    event: ChangeEvent<{ value: string }>,
+    event: ChangeEvent<{ value: unknown }>,
     name: string
   ) => {
-    setByName(name, event.target.value);
+    setByName(name, event.target.value as string);
   };
 
   const handleSwitchChange = (name: string, value: string) => {
@@ -180,21 +181,20 @@ const SettingsForm = ({
                 )}
 
                 {name === Settings.GroupSettings.VotingType && (
-                  <NativeSelect
+                  <Dropdown
                     value={value}
                     onChange={(e) => handleSettingChange(e, name)}
                   >
-                    <option aria-label={Messages.forms.none()} value="" />
-                    <option value={Votes.VotingTypes.Consensus}>
+                    <MenuItem value={Votes.VotingTypes.Consensus}>
                       {Messages.votes.votingTypes.consensus()}
-                    </option>
-                    <option value={Votes.VotingTypes.XToPass}>
+                    </MenuItem>
+                    <MenuItem value={Votes.VotingTypes.XToPass}>
                       {Messages.votes.votingTypes.xToPass()}
-                    </option>
-                    <option value={Votes.VotingTypes.Majority}>
+                    </MenuItem>
+                    <MenuItem value={Votes.VotingTypes.Majority}>
                       {Messages.votes.votingTypes.majority()}
-                    </option>
-                  </NativeSelect>
+                    </MenuItem>
+                  </Dropdown>
                 )}
 
                 {name === Settings.GroupSettings.VoteVerification && (

--- a/src/components/Shared/Dropdown.tsx
+++ b/src/components/Shared/Dropdown.tsx
@@ -1,0 +1,16 @@
+import { Select, SelectProps } from "@material-ui/core";
+
+const Dropdown = (props: SelectProps) => {
+  return (
+    <Select
+      {...props}
+      MenuProps={{
+        getContentAnchorEl: null,
+      }}
+    >
+      {props.children}
+    </Select>
+  );
+};
+
+export default Dropdown;

--- a/src/components/Shared/Pagination.tsx
+++ b/src/components/Shared/Pagination.tsx
@@ -9,7 +9,6 @@ import {
   makeStyles,
   Theme,
   createStyles,
-  Select,
   MenuItem,
 } from "@material-ui/core";
 import { NavigateNext, NavigateBefore } from "@material-ui/icons";
@@ -18,6 +17,7 @@ import { paginationVar, feedVar } from "../../apollo/client/localState";
 import styles from "../../styles/Shared/Pagination.module.scss";
 import Messages from "../../utils/messages";
 import { Common } from "../../constants";
+import Dropdown from "./Dropdown";
 
 const useStyles = makeStyles((theme: Theme) => {
   const hideForMobile = {
@@ -124,7 +124,7 @@ const PageButtons = ({ bottom }: Props) => {
         {Messages.pagination.rowsPerPage()}
       </Typography>
 
-      <Select
+      <Dropdown
         value={pageSize}
         onChange={handlePageSizeChange}
         onClick={() => setSelectOpen(!selectOpen)}
@@ -141,7 +141,7 @@ const PageButtons = ({ bottom }: Props) => {
             {_pageSize}
           </MenuItem>
         ))}
-      </Select>
+      </Dropdown>
 
       <Typography className={styles.sequenceText} color="primary">
         {sequenceText()}

--- a/src/components/Users/Form.tsx
+++ b/src/components/Users/Form.tsx
@@ -177,7 +177,7 @@ const UserForm = ({ user, isEditing }: Props) => {
             </>
           )}
 
-          <SubmitButton disabled={!!formik.submitCount}>
+          <SubmitButton disabled={formik.isSubmitting}>
             {isEditing
               ? Messages.actions.save()
               : Messages.users.actions.signUp()}

--- a/src/components/Votes/Form.tsx
+++ b/src/components/Votes/Form.tsx
@@ -5,7 +5,7 @@ import {
   FormGroup,
   FormControl,
   InputLabel,
-  NativeSelect,
+  MenuItem,
 } from "@material-ui/core";
 import { Formik, FormikHelpers, Form, Field } from "formik";
 
@@ -17,6 +17,7 @@ import Messages from "../../utils/messages";
 import { useCurrentUser } from "../../hooks";
 import SubmitButton from "../Shared/SubmitButton";
 import TextField from "../Shared/TextField";
+import Dropdown from "../Shared/Dropdown";
 
 interface FormValues {
   body: string;
@@ -42,6 +43,7 @@ const VotesForm = ({
   const [flipState, setFlipState] = useState<string>("");
   const [consensusState, setConsensusState] = useState<string>("");
   const [updateVote] = useMutation(UPDATE_VOTE);
+  const body = vote.body || "";
 
   useEffect(() => {
     if (modelOfConsensus) setConsensusState(vote.consensusState);
@@ -50,7 +52,7 @@ const VotesForm = ({
 
   const handleSubmit = async (
     { body }: FormValues,
-    { setSubmitting, resetForm }: FormikHelpers<FormValues>
+    { setSubmitting }: FormikHelpers<FormValues>
   ) => {
     if (currentUser) {
       try {
@@ -81,10 +83,7 @@ const VotesForm = ({
             motionVar({ ...motionFromGlobal, stage: Motions.Stages.Ratified });
           }
 
-          resetForm();
           setSubmitting(false);
-          setFlipState("");
-          setConsensusState("");
         } else {
           Router.push(`/motions/${vote.motionId}`);
         }
@@ -95,10 +94,11 @@ const VotesForm = ({
   };
 
   const handleVoteTypeChange = (
-    event: React.ChangeEvent<{ value: string }>
+    event: React.ChangeEvent<{ value: unknown }>
   ) => {
-    if (modelOfConsensus) setConsensusState(event.target.value);
-    else setFlipState(event.target.value);
+    const { value } = event.target as { value: string };
+    if (modelOfConsensus) setConsensusState(value);
+    else setFlipState(value);
   };
 
   const placeholderText = () => {
@@ -125,7 +125,7 @@ const VotesForm = ({
   };
 
   return (
-    <Formik initialValues={{ body: vote.body }} onSubmit={handleSubmit}>
+    <Formik initialValues={{ body }} onSubmit={handleSubmit}>
       {(formik) => (
         <Form className={onEditPage ? styles.formOnEditPage : styles.form}>
           <FormGroup>
@@ -136,47 +136,41 @@ const VotesForm = ({
               autoComplete="off"
             />
 
-            <FormControl style={{ marginBottom: "20px" }}>
+            <FormControl style={{ marginBottom: 20 }}>
               <InputLabel>
                 {modelOfConsensus
                   ? Messages.votes.form.agreeOrDisagree()
                   : Messages.votes.form.supportOrBlock()}
               </InputLabel>
-              <NativeSelect
-                value={selectValue()}
-                onChange={handleVoteTypeChange}
-              >
-                <option aria-label={Messages.forms.none()} value="" />
-                {modelOfConsensus ? (
-                  <>
-                    <option value={Votes.ConsensusStates.Agreement}>
-                      {Messages.votes.consensus.voteTypes.names.agreement()}
-                    </option>
-                    <option value={Votes.ConsensusStates.Reservations}>
-                      {Messages.votes.consensus.voteTypes.names.reservations()}
-                    </option>
-                    <option value={Votes.ConsensusStates.StandAside}>
-                      {Messages.votes.consensus.voteTypes.names.standAside()}
-                    </option>
-                    <option value={Votes.ConsensusStates.Block}>
-                      {Messages.votes.consensus.voteTypes.names.block()}
-                    </option>
-                  </>
-                ) : (
-                  <>
-                    <option value={Votes.FlipStates.Up}>
-                      {Messages.votes.actions.support()}
-                    </option>
-                    <option value={Votes.FlipStates.Down}>
-                      {Messages.votes.actions.block()}
-                    </option>
-                  </>
-                )}
-              </NativeSelect>
+              {modelOfConsensus ? (
+                <Dropdown value={selectValue()} onChange={handleVoteTypeChange}>
+                  <MenuItem value={Votes.ConsensusStates.Agreement}>
+                    {Messages.votes.consensus.voteTypes.names.agreement()}
+                  </MenuItem>
+                  <MenuItem value={Votes.ConsensusStates.Reservations}>
+                    {Messages.votes.consensus.voteTypes.names.reservations()}
+                  </MenuItem>
+                  <MenuItem value={Votes.ConsensusStates.StandAside}>
+                    {Messages.votes.consensus.voteTypes.names.standAside()}
+                  </MenuItem>
+                  <MenuItem value={Votes.ConsensusStates.Block}>
+                    {Messages.votes.consensus.voteTypes.names.block()}
+                  </MenuItem>
+                </Dropdown>
+              ) : (
+                <Dropdown value={selectValue()} onChange={handleVoteTypeChange}>
+                  <MenuItem value={Votes.FlipStates.Up}>
+                    {Messages.votes.actions.support()}
+                  </MenuItem>
+                  <MenuItem value={Votes.FlipStates.Down}>
+                    {Messages.votes.actions.block()}
+                  </MenuItem>
+                </Dropdown>
+              )}
             </FormControl>
           </FormGroup>
 
-          <SubmitButton disabled={!!formik.submitCount}>
+          <SubmitButton disabled={formik.isSubmitting}>
             {Messages.votes.actions.update()}
           </SubmitButton>
         </Form>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -293,10 +293,10 @@ const en = {
         oneDay: () => "1 day",
         sevenDays: () => "7 days",
         oneMonth: () => "1 month",
-        never: () => "Never",
+        never: () => "Never (default)",
       },
       maxUsesOptions: {
-        noLimit: () => "No limit",
+        noLimit: () => "No limit (default)",
         xUses: (x: number) => `${x} use${x === 1 ? "" : "s"}`,
       },
       labels: {

--- a/src/pages/users/login.tsx
+++ b/src/pages/users/login.tsx
@@ -78,7 +78,7 @@ const Login = () => {
             />
           </FormGroup>
 
-          <SubmitButton disabled={!!formik.submitCount}>
+          <SubmitButton disabled={formik.isSubmitting}>
             {Messages.users.actions.logIn()}
           </SubmitButton>
         </Form>

--- a/src/styles/Shared/globals.scss
+++ b/src/styles/Shared/globals.scss
@@ -49,9 +49,3 @@ a:hover {
 *:focus {
   outline: none !important;
 }
-
-// TODO: This should be removed after converting to Select component
-.MuiNativeSelect-select:not([multiple]) option {
-  background-color: $darkGray !important;
-  font-family: Helvetica !important;
-}

--- a/src/styles/Shared/theme.ts
+++ b/src/styles/Shared/theme.ts
@@ -68,12 +68,6 @@ const muiTheme = createTheme({
       },
     },
 
-    MuiNativeSelect: {
-      select: {
-        color: globalTheme.palette.primary.dark,
-      },
-    },
-
     MuiSwitch: {
       root: {
         "& .Mui-checked .MuiSwitch-thumb": {


### PR DESCRIPTION
This PR replaces all instances of MUIs `NativeSelect` component with `Select`.

#### Changes
- Migrated to `Select` in the following forms:
  - ServerInvite
  - Setting
  - Motion
  - Vote
- Added `Dropdown` shared component
- Resolved `null` input error for `vote.body` in `VoteForm`