### PR TITLE
Added useIsMountedRef hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Praxis is free and open source software, as specified by the GNU General Public 
 5. Create a `.env` file and include your database URL as `DATABASE_URL`
 6. Generate the Prisma client: `yarn prisma generate`
 7. Run the database migrations: `yarn prisma migrate dev --preview-feature`
-8. Start development server: `yarn dev`
+8. Run `mkdir public/uploads` to enable image uploads
+9. Start development server: `yarn dev`
+10. To create first user, navigate to http://localhost:3000/users/signup
+11. To test out roles and permissions features, navigate to http://localhost:3000/roles
 
 The default database is PostgreSQL.
 

--- a/src/components/Motions/CardFooter.tsx
+++ b/src/components/Motions/CardFooter.tsx
@@ -18,6 +18,7 @@ import {
   ToastStatus,
 } from "../../constants/common";
 import { TOTAL_COMMENTS_BY_MOTION_ID } from "../../apollo/client/queries";
+import { toCommentsQuery, toFocusQuery } from "../Posts/CardFooter";
 import styles from "../../styles/Shared/CardFooter.module.scss";
 import { BLURPLE } from "../../styles/Shared/theme";
 import { noCache } from "../../utils/apollo";
@@ -56,8 +57,6 @@ const CardFooter = ({ motionId, votes, setVotes, modelOfConsensus }: Props) => {
   const router = useRouter();
 
   const motionPagePath = `${ResourcePaths.Motion}${motionId}`;
-  const toCommentsQuery = "?comments=true";
-  const toFocusQuery = "&focus=true";
 
   useEffect(() => {
     if (totalCommentsRes.data)

--- a/src/components/Posts/CardFooter.tsx
+++ b/src/components/Posts/CardFooter.tsx
@@ -35,6 +35,9 @@ const useStyles = makeStyles(() =>
   })
 );
 
+export const toCommentsQuery = "?comments=true";
+export const toFocusQuery = "&focus=true";
+
 interface Props {
   postId: string;
 }
@@ -51,7 +54,7 @@ const CardFooter = ({ postId }: Props) => {
   const classes = useStyles();
   const router = useRouter();
 
-  const linkToPostPage = `${ResourcePaths.Post}${postId}`;
+  const postPagePath = `${ResourcePaths.Post}${postId}`;
 
   useEffect(() => {
     if (postId && likesByPostIdRes.data)
@@ -87,7 +90,7 @@ const CardFooter = ({ postId }: Props) => {
           )}
         </Typography>
         {!!totalComments && (
-          <Link href={linkToPostPage} passHref>
+          <Link href={postPagePath} passHref>
             <a>
               <Typography className={styles.totalCommentsLink}>
                 {Messages.comments.totalComments(totalComments)}
@@ -103,7 +106,11 @@ const CardFooter = ({ postId }: Props) => {
         <ActionLikeButton postId={postId} likes={likes} setLikes={setLikes} />
 
         <ActionButton
-          href={onPostPage() ? undefined : linkToPostPage}
+          href={
+            onPostPage()
+              ? undefined
+              : postPagePath + toCommentsQuery + toFocusQuery
+          }
           onClick={() => {
             if (onPostPage()) focusVar(FocusTargets.CommentFormTextField);
           }}

--- a/src/components/Roles/Member.tsx
+++ b/src/components/Roles/Member.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, IconButton } from "@material-ui/core";
+import { IconButton, LinearProgress } from "@material-ui/core";
 import { RemoveCircle } from "@material-ui/icons";
 
 import UserAvatar from "../Users/Avatar";
@@ -48,7 +48,7 @@ const RoleMember = ({ member, members, setMembers }: Props) => {
         </IconButton>
       </div>
     );
-  return <CircularProgress />;
+  return <LinearProgress />;
 };
 
 export default RoleMember;

--- a/src/components/Roles/MemberAdd.tsx
+++ b/src/components/Roles/MemberAdd.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, CircularProgress } from "@material-ui/core";
+import { Checkbox, LinearProgress } from "@material-ui/core";
 import UserAvatar from "../Users/Avatar";
 import styles from "../../styles/Role/Member.module.scss";
 import { useUserById } from "../../hooks";
@@ -41,7 +41,7 @@ const RoleMemberAdd = ({ userId, selectedUsers, setSelectedUsers }: Props) => {
         />
       </div>
     );
-  return <CircularProgress />;
+  return <LinearProgress />;
 };
 
 export default RoleMemberAdd;

--- a/src/components/Shared/Modal.tsx
+++ b/src/components/Shared/Modal.tsx
@@ -7,14 +7,12 @@ import {
   IconButton,
   Typography,
   Container,
-  useMediaQuery,
-  useTheme,
   Theme,
   createStyles,
 } from "@material-ui/core";
 import { Close } from "@material-ui/icons";
 import { CircularProgress, Fade } from "@material-ui/core";
-import { DESKTOP_BREAKPOINT } from "../../constants/common";
+import { useIsDesktop } from "../../hooks";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -56,8 +54,7 @@ const Modal = ({
   topGap,
   open,
 }: Props) => {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down(DESKTOP_BREAKPOINT));
+  const isMobile = !useIsDesktop();
   const classes = useStyles();
 
   const handleCloseDialog = () => {

--- a/src/components/Votes/Chip.tsx
+++ b/src/components/Votes/Chip.tsx
@@ -7,16 +7,14 @@ import {
   makeStyles,
   Theme,
   createStyles,
-  useTheme,
-  useMediaQuery,
 } from "@material-ui/core";
 import { SvgIconComponent } from "@material-ui/icons";
 
 import styles from "../../styles/Vote/Chips.module.scss";
-import { DESKTOP_BREAKPOINT } from "../../constants/common";
 import { ConsensusStates } from "../../constants/vote";
 import Messages from "../../utils/messages";
 import Voter from "./Voter";
+import { useIsDesktop } from "../../hooks";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -47,9 +45,8 @@ const VoteChip = ({
 }: ChipProps) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const popoverOpen = Boolean(anchorEl);
+  const isDesktop = useIsDesktop();
   const classes = useStyles();
-  const theme = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up(DESKTOP_BREAKPOINT));
   const SvgIcon = icon;
 
   const handlePopoverOpen = (

--- a/src/components/Votes/Form.tsx
+++ b/src/components/Votes/Form.tsx
@@ -7,7 +7,7 @@ import {
   InputLabel,
   MenuItem,
 } from "@material-ui/core";
-import { Formik, FormikHelpers, Form, Field } from "formik";
+import { Formik, Form, Field } from "formik";
 
 import { motionVar } from "../../apollo/client/localState";
 import { UPDATE_VOTE } from "../../apollo/client/mutations";
@@ -17,8 +17,8 @@ import { useCurrentUser } from "../../hooks";
 import SubmitButton from "../Shared/SubmitButton";
 import TextField from "../Shared/TextField";
 import Dropdown from "../Shared/Dropdown";
-import { FieldNames, ResourcePaths } from "../../constants/common";
 import { Stages } from "../../constants/motion";
+import { FieldNames, ResourcePaths } from "../../constants/common";
 import { ConsensusStates, FlipStates } from "../../constants/vote";
 
 interface FormValues {
@@ -52,10 +52,7 @@ const VotesForm = ({
     else setFlipState(vote.flipState);
   }, [vote, modelOfConsensus]);
 
-  const handleSubmit = async (
-    { body }: FormValues,
-    { setSubmitting }: FormikHelpers<FormValues>
-  ) => {
+  const handleSubmit = async ({ body }: FormValues) => {
     if (currentUser) {
       try {
         const { data } = await updateVote({
@@ -67,6 +64,10 @@ const VotesForm = ({
           },
         });
         if (setVotes && votes) {
+          if (data.updateVote.motionRatified && motionFromGlobal) {
+            motionVar({ ...motionFromGlobal, stage: Stages.Ratified });
+          }
+
           setVotes(
             votes.map((vote) => {
               const newVote: Vote = data.updateVote.vote;
@@ -80,12 +81,6 @@ const VotesForm = ({
               return vote;
             })
           );
-
-          if (data.updateVote.motionRatified && motionFromGlobal) {
-            motionVar({ ...motionFromGlobal, stage: Stages.Ratified });
-          }
-
-          setSubmitting(false);
         } else {
           Router.push(`${ResourcePaths.Motion}${vote.motionId}`);
         }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -84,6 +84,7 @@ export enum KeyCodes {
 
 export enum Events {
   Keydown = "keydown",
+  Resize = "resize",
 }
 
 export enum FocusTargets {

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -1,4 +1,26 @@
-import { useEffect, useState } from "react";
+import { MutableRefObject, useEffect, useRef, useState } from "react";
+import { useMediaQuery, useTheme } from "@material-ui/core";
+import { DESKTOP_BREAKPOINT, Events } from "../constants/common";
+
+// TODO: Use useIsMountedRef to resolve the following warning:
+// Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function
+// Solution found here: https://www.debuggr.io/react-update-unmounted-component
+// Please close the following issue once all warnings have been resolved:
+// https://github.com/forrestwilkins/praxis/issues/26
+
+export const useIsMountedRef = (): MutableRefObject<boolean | null> => {
+  const isMountedRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  return isMountedRef;
+};
 
 export const useWindowSize = () => {
   const [size, setSize] = useState([0, 0]);
@@ -8,9 +30,15 @@ export const useWindowSize = () => {
       setSize([window.innerWidth, window.innerHeight]);
     };
     updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
+    window.addEventListener(Events.Resize, updateSize);
+    return () => window.removeEventListener(Events.Resize, updateSize);
   }, []);
 
   return size;
+};
+
+export const useIsDesktop = (): boolean => {
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up(DESKTOP_BREAKPOINT));
+  return isDesktop;
 };

--- a/src/pages/motions/[id].tsx
+++ b/src/pages/motions/[id].tsx
@@ -21,7 +21,7 @@ import CommentsList from "../../components/Comments/List";
 import VotesList from "../../components/Votes/List";
 import Messages from "../../utils/messages";
 import { noCache } from "../../utils/apollo";
-import { useCurrentUser } from "../../hooks";
+import { useCurrentUser, useIsDesktop } from "../../hooks";
 import { FocusTargets } from "../../constants/common";
 
 const Show = () => {
@@ -40,6 +40,7 @@ const Show = () => {
     COMMENTS_BY_MOTION_ID,
     noCache
   );
+  const isDesktop = useIsDesktop();
 
   useEffect(() => {
     if (query.id) {
@@ -89,8 +90,8 @@ const Show = () => {
 
   useEffect(() => {
     if (query.comments) setTab(1);
-    if (query.focus) focusVar(FocusTargets.CommentFormTextField);
-  }, [query.comments, query.focus]);
+    if (query.focus && isDesktop) focusVar(FocusTargets.CommentFormTextField);
+  }, [query.comments, query.focus, isDesktop]);
 
   const deleteMotionHandler = async (id: string) => {
     await deleteMotion({

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -9,7 +9,9 @@ import Post from "../../components/Posts/Post";
 import CommentsForm from "../../components/Comments/Form";
 import CommentsList from "../../components/Comments/List";
 import { noCache } from "../../utils/apollo";
-import { useCurrentUser } from "../../hooks";
+import { useCurrentUser, useIsDesktop } from "../../hooks";
+import { focusVar } from "../../apollo/client/localState";
+import { FocusTargets } from "../../constants/common";
 
 const Show = () => {
   const { query } = useRouter();
@@ -24,6 +26,7 @@ const Show = () => {
     COMMENTS_BY_POST_ID,
     noCache
   );
+  const isDesktop = useIsDesktop();
 
   useEffect(() => {
     if (query.id)
@@ -44,6 +47,11 @@ const Show = () => {
     if (commentsRes.data)
       setComments(commentsRes.data.commentsByPostId.comments);
   }, [commentsRes.data]);
+
+  useEffect(() => {
+    if (query.comments && query.focus && isDesktop)
+      focusVar(FocusTargets.CommentFormTextField);
+  }, [query.comments, query.focus, isDesktop]);
 
   const deletePostHandler = async (id: string) => {
     await deletePost({


### PR DESCRIPTION
This PR adds a custom hook to help resolve the following warning:

> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function

#### Changes
- Resolved the above warning for the following components:
  - `VotesForm`
- Added `useIsMountedRef` hook
- Added todo comment for using hook, as shown [here](https://www.debuggr.io/react-update-unmounted-component/)
- Updated `README.md` to include more setup instructions for development
- Updated to `LinearProgress` for loading role members
- Implemented focus for posts page comments field
- Added `useIsDesktop` hook

The `useIsMountedRef` hook may not be sufficient to resolve the warning for all components. Other solutions may still have to be utilized.