### PR TITLE
Motions to change group roles

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaFeatures": { "jsx": true }
+    "ecmaFeatures": { "jsx": true },
+    "project": ["./tsconfig.json"]
   },
   "env": {
     "browser": true,
@@ -29,6 +30,7 @@
       "error",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
     ],
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/anchor-is-valid": [
       "error",

--- a/src/apollo/client/mutations/role.ts
+++ b/src/apollo/client/mutations/role.ts
@@ -56,7 +56,6 @@ export const UPDATE_PERMISSIONS = gql`
         id
         roleId
         name
-        description
         enabled
         createdAt
       }

--- a/src/apollo/client/queries/role.ts
+++ b/src/apollo/client/queries/role.ts
@@ -36,7 +36,6 @@ export const PERMISSIONS_BY_ROLE_ID = gql`
       id
       roleId
       name
-      description
       enabled
       createdAt
     }

--- a/src/apollo/models/role.ts
+++ b/src/apollo/models/role.ts
@@ -1,107 +1,10 @@
 import { Role, Group } from "@prisma/client";
-import { ModelNames } from "../../constants/common";
 import {
   ADMIN_ROLE_NAME,
   DEFAULT_ROLE_COLOR,
-  GlobalPermissions,
-  GroupPermissions,
+  INITIAL_GROUP_ADMIN_PERMISSIONS,
 } from "../../constants/role";
 import prisma from "../../utils/initPrisma";
-import Messages from "../../utils/messages";
-
-export interface InitialPermission {
-  name: string;
-  description: string;
-  enabled: boolean;
-}
-
-export const initialGlobalPermissions = (
-  isAdmin = false
-): InitialPermission[] => [
-  {
-    name: GlobalPermissions.ManagePosts,
-    description: Messages.roles.permissions.descriptions.manageItems(
-      ModelNames.Post
-    ),
-    enabled: isAdmin,
-  },
-  {
-    name: GlobalPermissions.ManageComments,
-    description: Messages.roles.permissions.descriptions.manageItems(
-      ModelNames.Comment
-    ),
-    enabled: isAdmin,
-  },
-  {
-    name: GlobalPermissions.ManageUsers,
-    description: Messages.roles.permissions.descriptions.manageUsers(),
-    enabled: isAdmin,
-  },
-  {
-    name: GlobalPermissions.ManageRoles,
-    description: Messages.roles.permissions.descriptions.manageRoles(),
-    enabled: isAdmin,
-  },
-  {
-    name: GlobalPermissions.ManageInvites,
-    description: Messages.roles.permissions.descriptions.manageInvites(),
-    enabled: isAdmin,
-  },
-  {
-    name: GlobalPermissions.CreateInvites,
-    description: Messages.roles.permissions.descriptions.createInvites(),
-    enabled: isAdmin,
-  },
-];
-
-export const initialGroupPermissions = (
-  isAdmin = false
-): InitialPermission[] => [
-  {
-    name: GroupPermissions.ManagePosts,
-    description: Messages.roles.permissions.descriptions.manageItems(
-      ModelNames.Post
-    ),
-    enabled: isAdmin,
-  },
-  {
-    name: GroupPermissions.ManageComments,
-    description: Messages.roles.permissions.descriptions.manageItems(
-      ModelNames.Comment
-    ),
-    enabled: isAdmin,
-  },
-  {
-    name: GroupPermissions.AcceptMemberRequests,
-    description: Messages.roles.permissions.descriptions.acceptMemberRequests(),
-    enabled: isAdmin,
-  },
-  {
-    name: GroupPermissions.KickMembers,
-    description: Messages.roles.permissions.descriptions.kickGroupMembers(),
-    enabled: isAdmin,
-  },
-  {
-    name: GroupPermissions.ManageRoles,
-    description: Messages.roles.permissions.descriptions.manageRoles(),
-    enabled: isAdmin,
-  },
-  {
-    name: GroupPermissions.ManageSettings,
-    description: Messages.roles.permissions.descriptions.manageGroupSettings(),
-    enabled: isAdmin,
-  },
-  {
-    name: GroupPermissions.EditGroup,
-    description: Messages.roles.permissions.descriptions.editGroup(),
-    enabled: isAdmin,
-  },
-  {
-    name: GroupPermissions.DeleteGroup,
-    description: Messages.roles.permissions.descriptions.deleteGroup(),
-    enabled: isAdmin,
-  },
-];
 
 export const initializePermissions = async (
   permissions: InitialPermission[],
@@ -133,7 +36,7 @@ export const initializeGroupAdminRole = async (group: Group) => {
       },
     },
   });
-  initializePermissions(initialGroupPermissions(true), adminRole);
+  initializePermissions(INITIAL_GROUP_ADMIN_PERMISSIONS, adminRole);
   await prisma.roleMember.create({
     data: {
       user: {

--- a/src/apollo/resolvers/permission.ts
+++ b/src/apollo/resolvers/permission.ts
@@ -100,7 +100,9 @@ const permissionResolvers = {
           roleId: parseInt(roleId),
         },
       });
-      return permissions;
+      return permissions.sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      );
     },
   },
 

--- a/src/apollo/resolvers/role.ts
+++ b/src/apollo/resolvers/role.ts
@@ -1,12 +1,14 @@
 import prisma from "../../utils/initPrisma";
 import Messages from "../../utils/messages";
 import { TypeNames } from "../../constants/common";
-import { ADMIN_ROLE_NAME, DEFAULT_ROLE_COLOR } from "../../constants/role";
 import {
-  initializePermissions,
-  initialGlobalPermissions,
-  initialGroupPermissions,
-} from "../models/role";
+  ADMIN_ROLE_NAME,
+  DEFAULT_ROLE_COLOR,
+  INITIAL_GLOBAL_ADMIN_PERMISSIONS,
+  INITIAL_GLOBAL_PERMISSIONS,
+  INITIAL_GROUP_PERMISSIONS,
+} from "../../constants/role";
+import { initializePermissions } from "../models/role";
 
 interface RoleInput {
   name: string;
@@ -71,7 +73,7 @@ const roleResolvers = {
         },
       });
       initializePermissions(
-        groupId ? initialGroupPermissions() : initialGlobalPermissions(),
+        groupId ? INITIAL_GROUP_PERMISSIONS : INITIAL_GLOBAL_PERMISSIONS,
         role
       );
       return { role };
@@ -120,7 +122,7 @@ const roleResolvers = {
           global: true,
         },
       });
-      initializePermissions(initialGlobalPermissions(true), role);
+      initializePermissions(INITIAL_GLOBAL_ADMIN_PERMISSIONS, role);
       await prisma.roleMember.create({
         data: {
           user: {

--- a/src/apollo/typeDefs/motion.ts
+++ b/src/apollo/typeDefs/motion.ts
@@ -17,6 +17,10 @@ input ActionDataInput {
   groupImage: FileUpload
   groupDescription: String
   groupSettings: [SettingInput]
+  groupRole: CreateRoleInput
+  groupRolePermissions: [ProposedPermissionInput]
+  groupRoleId: String
+  userId: String
 }
 
 input CreateMotionInput {

--- a/src/apollo/typeDefs/permission.ts
+++ b/src/apollo/typeDefs/permission.ts
@@ -4,7 +4,6 @@ type Permission {
   id: ID!
   roleId: ID!
   name: String!
-  description: String!
   enabled: Boolean!
   createdAt: String!
   updatedAt: String!
@@ -12,6 +11,11 @@ type Permission {
 
 input PermissionInput {
   id: ID!
+  enabled: Boolean!
+}
+
+input ProposedPermissionInput {
+  name: String!
   enabled: Boolean!
 }
 

--- a/src/components/Groups/Group.tsx
+++ b/src/components/Groups/Group.tsx
@@ -23,7 +23,7 @@ import {
   useSettingsByGroupId,
 } from "../../hooks";
 import CompactText from "../Shared/CompactText";
-import { noCache, settingValueByName } from "../../utils/clientIndex";
+import { noCache, settingValue } from "../../utils/clientIndex";
 import { GroupPermissions } from "../../constants/role";
 import GroupItemMenu from "./ItemMenu";
 
@@ -70,8 +70,7 @@ const Group = ({ group, deleteGroup }: Props) => {
 
   const isNoAdmin = (): boolean => {
     return (
-      settingValueByName(GroupSettings.NoAdmin, groupSettings) ===
-      SettingStates.On
+      settingValue(GroupSettings.NoAdmin, groupSettings) === SettingStates.On
     );
   };
 

--- a/src/components/Groups/PageHeader.tsx
+++ b/src/components/Groups/PageHeader.tsx
@@ -32,7 +32,7 @@ import { NavigationPaths, ResourcePaths } from "../../constants/common";
 import Messages from "../../utils/messages";
 import JoinButton from "./JoinButton";
 import { VotingTypes } from "../../constants/vote";
-import { noCache, settingValueByName } from "../../utils/clientIndex";
+import { noCache, settingValue } from "../../utils/clientIndex";
 import { GroupPermissions } from "../../constants/role";
 import GroupItemMenu from "./ItemMenu";
 
@@ -105,8 +105,7 @@ const GroupPageHeader = ({ group, deleteGroup }: Props) => {
 
   const isNoAdmin = (): boolean => {
     return (
-      settingValueByName(GroupSettings.NoAdmin, groupSettings) ===
-      SettingStates.On
+      settingValue(GroupSettings.NoAdmin, groupSettings) === SettingStates.On
     );
   };
 
@@ -124,7 +123,7 @@ const GroupPageHeader = ({ group, deleteGroup }: Props) => {
   };
 
   const votingType = (): string => {
-    const setting = settingValueByName(GroupSettings.VotingType, groupSettings);
+    const setting = settingValue(GroupSettings.VotingType, groupSettings);
     const votingTypes = Messages.groups.votingTypeLabels;
     switch (setting) {
       case VotingTypes.Majority:
@@ -168,7 +167,7 @@ const GroupPageHeader = ({ group, deleteGroup }: Props) => {
       )}
 
       <Image
-        src={(baseUrl + coverPhoto?.path) as string}
+        src={baseUrl + coverPhoto?.path}
         aspectRatio={isMobile ? 2 : 2.75}
         cover={true}
         color={BLACK}

--- a/src/components/Motions/ActionFields.tsx
+++ b/src/components/Motions/ActionFields.tsx
@@ -9,6 +9,7 @@ import {
 import { GroupAspects } from "../../constants/group";
 import styles from "../../styles/Motion/ActionFields.module.scss";
 import Messages from "../../utils/messages";
+import { ModelNames } from "../../constants/common";
 
 interface TextInputProps {
   value: string;
@@ -119,7 +120,8 @@ const ActionFields = ({ actionType, setActionData }: Props) => {
   if (
     actionType &&
     actionType !== ActionTypes.Test &&
-    actionType !== ActionTypes.ChangeSettings
+    actionType !== ActionTypes.ChangeSettings &&
+    !actionType.includes(ModelNames.Role)
   )
     return (
       <Typography gutterBottom>

--- a/src/components/Motions/Form.tsx
+++ b/src/components/Motions/Form.tsx
@@ -28,7 +28,7 @@ import {
   ResourcePaths,
   TruncationSizes,
 } from "../../constants/common";
-import { ActionTypeOptions, ActionTypes } from "../../constants/motion";
+import { ACTION_TYPE_OPTIONS, ActionTypes } from "../../constants/motion";
 import ActionFields from "./ActionFields";
 import { feedVar, paginationVar } from "../../apollo/client/localState";
 import { useCurrentUser, useIsMobile } from "../../hooks";
@@ -42,6 +42,7 @@ import Dropdown from "../Shared/Dropdown";
 import FormToggle from "./FormToggle";
 import GroupSettingsTab from "./GroupSettingsTab";
 import ActionData from "./ActionData";
+import GroupRolesTab from "./GroupRolesTab";
 
 const CardActions = withStyles(() =>
   createStyles({
@@ -118,9 +119,20 @@ const MotionsForm = ({
   }, [savedImagesRes.data]);
 
   useEffect(() => {
-    if (action === ActionTypes.ChangeSettings && (group || selectedGroupId))
-      setTab(1);
-    else setTab(0);
+    if (group || selectedGroupId) {
+      switch (action) {
+        case ActionTypes.ChangeSettings:
+          setTab(1);
+          break;
+        case ActionTypes.CreateRole:
+        case ActionTypes.ChangeRole:
+        case ActionTypes.AssignRole:
+          setTab(2);
+          break;
+        default:
+          setTab(0);
+      }
+    } else setTab(0);
   }, [action, group, selectedGroupId]);
 
   useEffect(() => {
@@ -234,6 +246,10 @@ const MotionsForm = ({
       : undefined;
   };
 
+  const resetTabs = () => {
+    setTab(0);
+  };
+
   return (
     <Formik
       initialValues={{
@@ -265,7 +281,7 @@ const MotionsForm = ({
                         {Messages.motions.form.motionType()}
                       </InputLabel>
                       <Dropdown value={action} onChange={handleActionChange}>
-                        {ActionTypeOptions.map((option) => (
+                        {ACTION_TYPE_OPTIONS.map((option) => (
                           <MenuItem value={option.value} key={option.value}>
                             {option.message}
                           </MenuItem>
@@ -275,7 +291,9 @@ const MotionsForm = ({
 
                     {groups ? (
                       <FormControl style={{ marginBottom: 18 }}>
-                        <InputLabel>{Messages.motions.form.group()}</InputLabel>
+                        <InputLabel>
+                          {Messages.motions.form.inputLabels.group()}
+                        </InputLabel>
                         <Dropdown
                           value={selectedGroupId}
                           onChange={handleGroupChange}
@@ -350,7 +368,18 @@ const MotionsForm = ({
               setSelectedGroupId={setSelectedGroupId}
               setActionData={setActionData}
               setAction={setAction}
-              resetTabs={() => setTab(0)}
+              resetTabs={resetTabs}
+            />
+          )}
+
+          {tab === 2 && (
+            <GroupRolesTab
+              groupId={group ? group.id : selectedGroupId}
+              setSelectedGroupId={setSelectedGroupId}
+              setActionData={setActionData}
+              setAction={setAction}
+              action={action}
+              resetTabs={resetTabs}
             />
           )}
         </>

--- a/src/components/Motions/GroupRolesTab.tsx
+++ b/src/components/Motions/GroupRolesTab.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useState } from "react";
+import {
+  FormControl,
+  FormGroup,
+  InputLabel,
+  LinearProgress,
+  MenuItem,
+  Typography,
+} from "@material-ui/core";
+import { Field, Form, Formik, FormikProps } from "formik";
+import { useLazyQuery } from "@apollo/client";
+import { ColorResult } from "react-color";
+
+import {
+  DEFAULT_ROLE_COLOR,
+  INITIAL_GROUP_PERMISSIONS,
+} from "../../constants/role";
+import Messages from "../../utils/messages";
+import CancelButton from "../Shared/CancelButton";
+import ColorPicker from "../Shared/ColorPicker";
+import SubmitButton from "../Shared/SubmitButton";
+import TextField from "../Shared/TextField";
+import styles from "../../styles/Shared/Shared.module.scss";
+import { noCache } from "../../utils/clientIndex";
+import {
+  PERMISSIONS_BY_ROLE_ID,
+  ROLES_BY_GROUP_ID,
+} from "../../apollo/client/queries";
+import { ActionTypes } from "../../constants/motion";
+import Dropdown from "../Shared/Dropdown";
+import { useMembersByGroupId } from "../../hooks";
+import PermissionToggles from "../Permissions/Toggles";
+import { FieldNames } from "../../constants/common";
+import UserName from "../Users/Name";
+
+interface FormValues {
+  name: string;
+}
+
+interface Props {
+  groupId: string;
+  action: string;
+  setSelectedGroupId: (id: string) => void;
+  setActionData: (actionData: ActionData | undefined) => void;
+  setAction: (action: string) => void;
+  resetTabs: () => void;
+}
+
+const GroupRolesTab = ({
+  groupId,
+  action,
+  setSelectedGroupId,
+  setActionData,
+  setAction,
+  resetTabs,
+}: Props) => {
+  const [color, setColor] = useState<string>(DEFAULT_ROLE_COLOR);
+  const [selectedRoleId, setSelectedRoleId] = useState("");
+  const [assigneeId, setAssigneeId] = useState("");
+  const [roles, setRoles] = useState<ClientRole[]>([]);
+  const [permissions, setPermissions] = useState<ClientPermission[]>([]);
+  const [unsavedPermissions, setUnsavedPermissions] = useState<
+    ClientPermission[]
+  >([]);
+  const [getRolesRes, rolesRes] = useLazyQuery(ROLES_BY_GROUP_ID, noCache);
+  const [getPermissionsRes, permissionsRes] = useLazyQuery(
+    PERMISSIONS_BY_ROLE_ID,
+    noCache
+  );
+  const [groupMembers, _, groupMembersLoading] = useMembersByGroupId(groupId);
+  const roleBySelectedId = roles.find((role) => role.id === selectedRoleId);
+  const initialValues: FormValues = {
+    name: roleBySelectedId ? roleBySelectedId.name : "",
+  };
+  const isCreatingRole = action === ActionTypes.CreateRole;
+  const isChangingRole = action === ActionTypes.ChangeRole;
+  const isAssigningRole = action === ActionTypes.AssignRole;
+
+  useEffect(() => {
+    if (groupId)
+      getRolesRes({
+        variables: { groupId },
+      });
+  }, [groupId]);
+
+  useEffect(() => {
+    if (selectedRoleId && isChangingRole) {
+      getPermissionsRes({
+        variables: {
+          roleId: selectedRoleId,
+        },
+      });
+    }
+  }, [selectedRoleId, action]);
+
+  useEffect(() => {
+    if (rolesRes.data) setRoles(rolesRes.data.rolesByGroupId);
+  }, [rolesRes.data]);
+
+  useEffect(() => {
+    if (permissionsRes.data)
+      setPermissions(permissionsRes.data.permissionsByRoleId);
+  }, [permissionsRes.data]);
+
+  useEffect(() => {
+    if (isCreatingRole)
+      setPermissions(INITIAL_GROUP_PERMISSIONS as ClientPermission[]);
+  }, [action]);
+
+  useEffect(() => {
+    if (isChangingRole && roleBySelectedId) setColor(roleBySelectedId.color);
+  }, [isChangingRole, roleBySelectedId]);
+
+  const handleSubmit = ({ name }: FormValues) => {
+    if (isCreatingRole || isChangingRole)
+      setActionData({
+        groupRole: { name, color },
+        groupRolePermissions: unsavedPermissions.map(({ name, enabled }) => {
+          return { name, enabled };
+        }),
+        ...(isChangingRole && {
+          groupRoleId: selectedRoleId,
+        }),
+      });
+    if (isAssigningRole)
+      setActionData({
+        groupRoleId: selectedRoleId,
+        userId: assigneeId,
+      });
+    resetTabs();
+  };
+
+  const handleCancel = () => {
+    setSelectedGroupId("");
+    setActionData(undefined);
+    setAction("");
+    resetTabs();
+  };
+
+  const handleColorChange = (color: ColorResult) => {
+    setColor(color.hex);
+  };
+
+  const handleRoleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSelectedRoleId(event.target.value as string);
+  };
+
+  const handleAssigneeChange = (
+    event: React.ChangeEvent<{ value: unknown }>
+  ) => {
+    setAssigneeId(event.target.value as string);
+  };
+
+  const isSubmitButtonDisabled = ({
+    isSubmitting,
+    dirty,
+  }: FormikProps<FormValues>): boolean => {
+    if (anyUnsavedColor() || anyUnsavedPermissions()) return false;
+    if (!dirty) return true;
+    return isSubmitting;
+  };
+
+  const anyUnsavedPermissions = (): boolean => {
+    return (
+      Boolean(unsavedPermissions.length) &&
+      JSON.stringify(permissions) !== JSON.stringify(unsavedPermissions)
+    );
+  };
+
+  const anyUnsavedColor = (): boolean => {
+    return roleBySelectedId?.color !== color;
+  };
+
+  const actionLabel = (): string => {
+    const actionTypes = Messages.motions.form.actionTypes;
+    switch (action) {
+      case ActionTypes.CreateRole:
+        return actionTypes.createRole();
+      case ActionTypes.ChangeRole:
+        return actionTypes.changeRole();
+      case ActionTypes.AssignRole:
+        return actionTypes.assignRole();
+      default:
+        return "";
+    }
+  };
+
+  if (rolesRes.loading || permissionsRes.loading || groupMembersLoading)
+    return <LinearProgress />;
+
+  return (
+    <>
+      <Typography gutterBottom>{actionLabel()}</Typography>
+
+      <Formik
+        initialValues={initialValues}
+        onSubmit={handleSubmit}
+        enableReinitialize
+      >
+        {(formik) => (
+          <Form>
+            <FormGroup>
+              {(isChangingRole || isAssigningRole) && (
+                <FormControl style={{ marginBottom: 6 }}>
+                  <InputLabel>
+                    {Messages.motions.form.inputLabels.role()}
+                  </InputLabel>
+                  <Dropdown value={selectedRoleId} onChange={handleRoleChange}>
+                    {roles.map((role) => (
+                      <MenuItem value={role.id} key={role.id}>
+                        {role.name}
+                      </MenuItem>
+                    ))}
+                  </Dropdown>
+                </FormControl>
+              )}
+
+              {isAssigningRole && (
+                <FormControl style={{ marginBottom: 18 }}>
+                  <InputLabel>
+                    {Messages.motions.form.inputLabels.member()}
+                  </InputLabel>
+                  <Dropdown value={assigneeId} onChange={handleAssigneeChange}>
+                    {groupMembers.map((member) => (
+                      <MenuItem value={member.userId} key={member.id}>
+                        <UserName userId={member.userId} />
+                      </MenuItem>
+                    ))}
+                  </Dropdown>
+                </FormControl>
+              )}
+
+              {(isCreatingRole || isChangingRole) && (
+                <>
+                  <Field
+                    name={FieldNames.Name}
+                    placeholder={Messages.roles.form.name()}
+                    component={TextField}
+                    autoComplete="off"
+                  />
+                  <ColorPicker
+                    color={color}
+                    onChange={handleColorChange}
+                    label={Messages.roles.form.colorPickerLabel()}
+                  />
+                </>
+              )}
+            </FormGroup>
+
+            {(isCreatingRole || isChangingRole) && (
+              <PermissionToggles
+                permissions={permissions}
+                unsavedPermissions={unsavedPermissions}
+                setUnsavedPermissions={setUnsavedPermissions}
+              />
+            )}
+
+            <div className={styles.flexEnd}>
+              <CancelButton
+                onClick={handleCancel}
+                style={{ marginRight: 12 }}
+              />
+
+              <SubmitButton disabled={isSubmitButtonDisabled(formik)}>
+                {Messages.actions.confirm()}
+              </SubmitButton>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </>
+  );
+};
+
+export default GroupRolesTab;

--- a/src/components/Motions/Motion.tsx
+++ b/src/components/Motions/Motion.tsx
@@ -39,7 +39,7 @@ import {
 import Messages from "../../utils/messages";
 import { timeAgo } from "../../utils/time";
 import CardFooter from "./CardFooter";
-import { settingValueByName } from "../../utils/setting";
+import { settingValue } from "../../utils/setting";
 
 const useStyles = makeStyles({
   title: {
@@ -129,7 +129,7 @@ const Motion = ({ motion, deleteMotion }: Props) => {
 
   const isModelOfConsensus = (): boolean => {
     return (
-      settingValueByName(GroupSettings.VotingType, groupSettings) ===
+      settingValue(GroupSettings.VotingType, groupSettings) ===
       VotingTypes.Consensus
     );
   };

--- a/src/components/Permissions/Form.tsx
+++ b/src/components/Permissions/Form.tsx
@@ -1,17 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { FormGroup, Switch } from "@material-ui/core";
 import { useMutation } from "@apollo/client";
-
 import styles from "../../styles/Role/Role.module.scss";
 import { UPDATE_PERMISSIONS } from "../../apollo/client/mutations";
 import { navKeyVar } from "../../apollo/client/localState";
 import SubmitButton from "../Shared/SubmitButton";
 import Messages from "../../utils/messages";
-import {
-  permissionDescription,
-  generateRandom,
-  displayName,
-} from "../../utils/clientIndex";
+import { generateRandom } from "../../utils/clientIndex";
+import PermissionToggles from "./Toggles";
 
 interface Props {
   permissions: ClientPermission[];
@@ -19,7 +14,7 @@ interface Props {
   unsavedPermissions: ClientPermission[];
   setUnsavedPermissions: (permissions: ClientPermission[]) => void;
   anyUnsavedPermissions: boolean;
-  setCanManageRolesDep: (dependency: string) => void;
+  setCanManageRolesDep?: (dependency: string) => void;
 }
 
 const PermissionsForm = ({
@@ -52,57 +47,21 @@ const PermissionsForm = ({
       setUnsavedPermissions(newPermissions);
       setPermissions(newPermissions);
       const newKey = generateRandom();
-      setCanManageRolesDep(newKey);
       navKeyVar(newKey);
+      if (setCanManageRolesDep) setCanManageRolesDep(newKey);
     } catch (err) {
       alert(err);
     }
     setSubmitLoading(false);
   };
 
-  const handleSwitchChange = (name: string, enabled: boolean) => {
-    setByName(name, enabled);
-  };
-
-  const setByName = (name: string, enabled: boolean) => {
-    setUnsavedPermissions(
-      unsavedPermissions.map((permission) => {
-        if (permission.name === name)
-          return {
-            ...permission,
-            enabled,
-          };
-        return permission;
-      })
-    );
-  };
-
   return (
     <form onSubmit={(e) => handleSubmit(e)} className={styles.form}>
-      <FormGroup>
-        <div className={styles.form}>
-          {unsavedPermissions.map(({ name, enabled }) => {
-            return (
-              <div className={styles.permission} key={name}>
-                <div>
-                  <div className={styles.permissionName}>
-                    {displayName(name)}
-                  </div>
-                  <div className={styles.permissionDescription}>
-                    {permissionDescription(name)}
-                  </div>
-                </div>
-
-                <Switch
-                  checked={enabled}
-                  onChange={() => handleSwitchChange(name, !enabled)}
-                  color="primary"
-                />
-              </div>
-            );
-          })}
-        </div>
-      </FormGroup>
+      <PermissionToggles
+        permissions={permissions}
+        unsavedPermissions={unsavedPermissions}
+        setUnsavedPermissions={setUnsavedPermissions}
+      />
 
       <div className={styles.flexEnd}>
         <SubmitButton disabled={!anyUnsavedPermissions}>

--- a/src/components/Permissions/Toggles.tsx
+++ b/src/components/Permissions/Toggles.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { FormGroup, Switch, Typography } from "@material-ui/core";
+import {
+  permissionDescription,
+  permissionDisplayName,
+} from "../../utils/clientIndex";
+import styles from "../../styles/Role/Role.module.scss";
+
+interface Props {
+  permissions: ClientPermission[];
+  unsavedPermissions: ClientPermission[];
+  setUnsavedPermissions: (permissions: ClientPermission[]) => void;
+}
+
+const PermissionToggles = ({
+  permissions,
+  unsavedPermissions,
+  setUnsavedPermissions,
+}: Props) => {
+  useEffect(() => {
+    setUnsavedPermissions(permissions);
+  }, [permissions]);
+
+  const handleSwitchChange = (name: string, enabled: boolean) => {
+    setByName(name, enabled);
+  };
+
+  const setByName = (name: string, enabled: boolean) => {
+    setUnsavedPermissions(
+      unsavedPermissions.map((permission) => {
+        if (permission.name === name)
+          return {
+            ...permission,
+            enabled,
+          };
+        return permission;
+      })
+    );
+  };
+
+  return (
+    <FormGroup>
+      {unsavedPermissions.map(({ name, enabled }) => {
+        return (
+          <div className={styles.permission} key={name}>
+            <div>
+              <Typography>{permissionDisplayName(name)}</Typography>
+              <div className={styles.permissionDescription}>
+                {permissionDescription(name)}
+              </div>
+            </div>
+
+            <Switch
+              checked={enabled}
+              onChange={() => handleSwitchChange(name, !enabled)}
+              color="primary"
+            />
+          </div>
+        );
+      })}
+    </FormGroup>
+  );
+};
+
+export default PermissionToggles;

--- a/src/components/Roles/Form.tsx
+++ b/src/components/Roles/Form.tsx
@@ -3,6 +3,7 @@ import { useMutation } from "@apollo/client";
 import { useRouter } from "next/router";
 import { Card, CardContent, FormGroup } from "@material-ui/core";
 import { Formik, FormikHelpers, Form, Field, FormikProps } from "formik";
+import { ColorResult } from "react-color";
 
 import { CREATE_ROLE, UPDATE_ROLE } from "../../apollo/client/mutations";
 import styles from "../../styles/Shared/Shared.module.scss";
@@ -90,7 +91,7 @@ const RoleForm = ({
     }
   };
 
-  const handleChangeComplete = (color: any) => {
+  const handleChangeComplete = (color: ColorResult) => {
     setColor(color.hex);
   };
 

--- a/src/components/Roles/Name.tsx
+++ b/src/components/Roles/Name.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@apollo/client";
+import { ROLE } from "../../apollo/client/queries";
+import { noCache } from "../../utils/apollo";
+
+const RoleName = ({ roleId }: { roleId: string }) => {
+  const [role, setRole] = useState<ClientRole>();
+  const roleRes = useQuery(ROLE, {
+    variables: { id: roleId },
+    ...noCache,
+  });
+
+  useEffect(() => {
+    if (roleRes.data) setRole(roleRes.data.role);
+  }, [roleRes.data]);
+
+  return <span style={{ color: role?.color }}>{role?.name}</span>;
+};
+
+export default RoleName;

--- a/src/components/Settings/Form.tsx
+++ b/src/components/Settings/Form.tsx
@@ -21,14 +21,14 @@ import { UPDATE_SETTINGS } from "../../apollo/client/mutations";
 import styles from "../../styles/Setting/SettingsForm.module.scss";
 import Messages from "../../utils/messages";
 import { useCurrentUser } from "../../hooks";
-import { displayName } from "../../utils/items";
 import SubmitButton from "../Shared/SubmitButton";
 import Dropdown from "../Shared/Dropdown";
 import CancelButton from "../Shared/CancelButton";
 import {
   canShowSetting,
-  descriptionByName,
-  settingValueByName,
+  settingDescription,
+  settingDisplayName,
+  settingValue,
 } from "../../utils/setting";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -95,10 +95,7 @@ const SettingsForm = ({
   const currentUser = useCurrentUser();
   const [submitLoading, setSubmitLoading] = useState<boolean>(false);
   const [updateSettings] = useMutation(UPDATE_SETTINGS);
-  const votingType = settingValueByName(
-    GroupSettings.VotingType,
-    unsavedSettings
-  );
+  const votingType = settingValue(GroupSettings.VotingType, unsavedSettings);
   const submitText = submitButtonText || Messages.actions.save();
   const classes = useStyles();
 
@@ -188,9 +185,11 @@ const SettingsForm = ({
               <Fragment key={id}>
                 <div className={styles.setting}>
                   <div>
-                    <div className={styles.name}>{displayName(name)}</div>
+                    <div className={styles.name}>
+                      {settingDisplayName(name)}
+                    </div>
                     <div className={styles.description}>
-                      {descriptionByName(name)}
+                      {settingDescription(name)}
                     </div>
                   </div>
 

--- a/src/components/Users/Name.tsx
+++ b/src/components/Users/Name.tsx
@@ -1,0 +1,15 @@
+import { LinearProgress } from "@material-ui/core";
+import { useUserById } from "../../hooks";
+
+interface Props {
+  userId: string;
+  noLoader?: boolean;
+}
+
+const UserName = ({ userId, noLoader }: Props) => {
+  const [user, _, userLoading] = useUserById(userId);
+  if (userLoading && !noLoader) return <LinearProgress />;
+  return <>{user?.name}</>;
+};
+
+export default UserName;

--- a/src/constants/group.ts
+++ b/src/constants/group.ts
@@ -3,4 +3,5 @@ export enum GroupAspects {
   Image = "image",
   Description = "description",
   Settings = "settings",
+  Role = "role",
 }

--- a/src/constants/motion.ts
+++ b/src/constants/motion.ts
@@ -1,6 +1,6 @@
 import Messages from "../utils/messages";
 
-export const MIN_GROUP_SIZE_FOR_RATIFICATION = 3;
+export const MIN_GROUP_SIZE_TO_RATIFY = 3;
 
 export enum ActionTypes {
   PlanEvent = "plan-event",
@@ -9,6 +9,9 @@ export enum ActionTypes {
   ChangeDescription = "change-description",
   ChangeSettings = "change-settings",
   ChangeRules = "change-rules",
+  CreateRole = "create-role",
+  ChangeRole = "change-role",
+  AssignRole = "assign-role",
   Test = "test",
 }
 
@@ -35,14 +38,10 @@ interface ActionTypeOption {
   value: ActionTypes;
 }
 
-export const ActionTypeOptions: ActionTypeOption[] = [
+export const ACTION_TYPE_OPTIONS: ActionTypeOption[] = [
   {
     message: Messages.motions.form.actionTypes.planEvent(),
     value: ActionTypes.PlanEvent,
-  },
-  {
-    message: Messages.motions.form.actionTypes.changeSettings(),
-    value: ActionTypes.ChangeSettings,
   },
   {
     message: Messages.motions.form.actionTypes.changeName(),
@@ -53,11 +52,27 @@ export const ActionTypeOptions: ActionTypeOption[] = [
     value: ActionTypes.ChangeDescription,
   },
   {
-    message: Messages.motions.form.actionTypes.test(),
-    value: ActionTypes.Test,
-  },
-  {
     message: Messages.motions.form.actionTypes.changeImage(),
     value: ActionTypes.ChangeImage,
+  },
+  {
+    message: Messages.motions.form.actionTypes.changeSettings(),
+    value: ActionTypes.ChangeSettings,
+  },
+  {
+    message: Messages.motions.form.actionTypes.createRole(),
+    value: ActionTypes.CreateRole,
+  },
+  {
+    message: Messages.motions.form.actionTypes.changeRole(),
+    value: ActionTypes.ChangeRole,
+  },
+  {
+    message: Messages.motions.form.actionTypes.assignRole(),
+    value: ActionTypes.AssignRole,
+  },
+  {
+    message: Messages.motions.form.actionTypes.test(),
+    value: ActionTypes.Test,
   },
 ];

--- a/src/constants/role.ts
+++ b/src/constants/role.ts
@@ -20,3 +20,37 @@ export enum GroupPermissions {
   ManageRoles = "manage-group-roles",
   ManageSettings = "manage-group-settings",
 }
+
+export const INITIAL_GLOBAL_PERMISSIONS: InitialPermission[] = [
+  GlobalPermissions.ManagePosts,
+  GlobalPermissions.ManageComments,
+  GlobalPermissions.ManageUsers,
+  GlobalPermissions.ManageRoles,
+  GlobalPermissions.ManageInvites,
+  GlobalPermissions.CreateInvites,
+].map((name) => {
+  return { name, enabled: false };
+});
+
+export const INITIAL_GROUP_PERMISSIONS: InitialPermission[] = [
+  GroupPermissions.ManagePosts,
+  GroupPermissions.ManageComments,
+  GroupPermissions.AcceptMemberRequests,
+  GroupPermissions.KickMembers,
+  GroupPermissions.ManageRoles,
+  GroupPermissions.ManageSettings,
+  GroupPermissions.EditGroup,
+  GroupPermissions.DeleteGroup,
+].map((name) => {
+  return { name, enabled: false };
+});
+
+export const INITIAL_GLOBAL_ADMIN_PERMISSIONS: InitialPermission[] =
+  INITIAL_GLOBAL_PERMISSIONS.map((permission) => {
+    return { ...permission, enabled: true };
+  });
+
+export const INITIAL_GROUP_ADMIN_PERMISSIONS: InitialPermission[] =
+  INITIAL_GROUP_PERMISSIONS.map((permission) => {
+    return { ...permission, enabled: true };
+  });

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -127,17 +127,25 @@ const en = {
     form: {
       makeAMotion: () => "Make a motion...",
       motionType: () => "Motion type",
-      group: () => "Group",
       actionTypes: {
         planEvent: () => "Plan event",
-        changeName: () => "Change name",
-        changeDescription: () => "Change description",
-        changeImage: () => "Change group image",
+        changeName: () => "Change group name",
+        changeDescription: () => "Change about text",
+        changeImage: () => "Change cover photo",
         changeSettings: () => "Change group settings",
+        changeRules: () => "Change group rules",
+        createRole: () => "Create a group role",
+        changeRole: () => "Change a group role",
+        assignRole: () => "Assign a group role",
         test: () => "Just a test",
       },
       motionEmpty: () => "Motion cannot be empty.",
       enterProposedSettings: () => "Enter your proposed settings below...",
+      inputLabels: {
+        group: () => "Group",
+        member: () => "Member",
+        role: () => "Role",
+      },
     },
     tabs: {
       comments: () => "Comments",
@@ -146,7 +154,9 @@ const en = {
       votes: () => "Votes",
     },
     groups: {
-      proposedAspect: (aspect: string) => `Proposed ${aspect}:`,
+      proposedAspect: (aspect: string) => `Proposed ${aspect}`,
+      proposedRoleChange: () => "Proposed role change",
+      proposedRoleAssignment: () => "Proposed role assignment",
       actionFields: {
         inDev: () => "This motion type is still in development...",
         newAspect: (aspect: string) => `New group ${aspect}`,
@@ -285,13 +295,13 @@ const en = {
     },
     groups: {
       names: {
-        noAdmin: () => "No admin",
-        votingType: () => "Voting model",
-        ratificationThreshold: () => "Ratification threshold",
-        reservationsLimit: () => "Reservations limit",
-        standAsidesLimit: () => "Stand asides limit",
-        xToPass: () => "X to pass",
-        xToBlock: () => "X to block",
+        noAdmin: () => "No Admin",
+        votingType: () => "Voting Model",
+        ratificationThreshold: () => "Ratification Threshold",
+        reservationsLimit: () => "Reservations Limit",
+        standAsidesLimit: () => "Stand Asides Limit",
+        xToPass: () => "X to Pass",
+        xToBlock: () => "X to Block",
       },
       descriptions: {
         noAdmin: () =>
@@ -343,24 +353,35 @@ const en = {
     },
     permissions: {
       names: {
-        manageItems: (itemType: string) => `Manage ${itemType}s`,
+        acceptMemberRequests: () => "Approve Member Requests",
+        createInvites: () => "Create Invites",
+        deleteGroup: () => "Delete Group",
+        editGroup: () => "Edit Group",
+        kickGroupMembers: () => "Kick Members",
+        manageUsers: () => "Manage Members",
+        managePosts: () => "Manage Posts",
+        manageComments: () => "Manage Comments",
+        manageInvites: () => "Manage Invites",
+        manageRoles: () => "Manage Roles",
+        manageSettings: () => "Manage Settings",
       },
       descriptions: {
         editGroup: () =>
-          "Allows members to edit the groups name, description, and cover photo.",
+          "Allows members to edit the group's name, description, and cover photo.",
         deleteGroup: () => "Allows members to permanently delete this group.",
-        manageItems: (itemType: string) =>
-          `Allows members to delete ${itemType}s by other members.`,
+        managePosts: () => "Allows members to delete posts by other members.",
+        manageComments: () =>
+          "Allows members to delete comments by other members.",
         manageRoles: () =>
           "Allows members to create new roles and edit or delete roles lower than their highest role.",
         manageGroupSettings: () =>
-          "Allows members to make changes to this groups settings.",
+          "Allows members to make changes to this group's settings.",
         acceptMemberRequests: () =>
           "Allows members to view member requests and to allow new members to join the group.",
         kickGroupMembers: () =>
           "Allows members to remove other members from the group.",
         manageUsers: () =>
-          "Allows members to view the full list of server members and permanently delete their accounts.",
+          "Allows members to view the full list of server members and kick other members from the server.",
         manageInvites: () =>
           "Allows members to view the full list of server invites.",
         createInvites: () =>

--- a/src/pages/groups/[name]/about.tsx
+++ b/src/pages/groups/[name]/about.tsx
@@ -22,7 +22,7 @@ import {
   canShowSetting,
   displayName,
   displaySettingValue,
-  settingValueByName,
+  settingValue,
 } from "../../../utils/clientIndex";
 import { GroupSettings } from "../../../constants/setting";
 
@@ -30,10 +30,7 @@ const GroupsAbout = () => {
   const { query } = useRouter();
   const [group, _, groupLoading] = useGroupByName(query.name);
   const [groupSettings] = useSettingsByGroupId(group?.id);
-  const votingType = settingValueByName(
-    GroupSettings.VotingType,
-    groupSettings
-  );
+  const votingType = settingValue(GroupSettings.VotingType, groupSettings);
 
   useEffect(() => {
     if (group)

--- a/src/pages/groups/[name]/edit.tsx
+++ b/src/pages/groups/[name]/edit.tsx
@@ -11,7 +11,7 @@ import {
   useSettingsByGroupId,
 } from "../../../hooks";
 import { GroupSettings, SettingStates } from "../../../constants/setting";
-import { settingValueByName } from "../../../utils/clientIndex";
+import { settingValue } from "../../../utils/clientIndex";
 import { GroupPermissions } from "../../../constants/role";
 import { breadcrumbsVar } from "../../../apollo/client/localState";
 import { ResourcePaths, TypeNames } from "../../../constants/common";
@@ -47,8 +47,7 @@ const Edit = () => {
 
   const isNoAdmin = (): boolean => {
     return (
-      settingValueByName(GroupSettings.NoAdmin, groupSettings) ===
-      SettingStates.On
+      settingValue(GroupSettings.NoAdmin, groupSettings) === SettingStates.On
     );
   };
 

--- a/src/pages/groups/[name]/requests.tsx
+++ b/src/pages/groups/[name]/requests.tsx
@@ -21,7 +21,7 @@ import {
   useMembersByGroupId,
   useSettingsByGroupId,
 } from "../../../hooks";
-import { noCache, settingValueByName } from "../../../utils/clientIndex";
+import { noCache, settingValue } from "../../../utils/clientIndex";
 import { GroupPermissions } from "../../../constants/role";
 
 const Requests = () => {
@@ -60,8 +60,7 @@ const Requests = () => {
 
   const isNoAdmin = (): boolean => {
     return (
-      settingValueByName(GroupSettings.NoAdmin, groupSettings) ===
-      SettingStates.On
+      settingValue(GroupSettings.NoAdmin, groupSettings) === SettingStates.On
     );
   };
 

--- a/src/pages/groups/[name]/settings.tsx
+++ b/src/pages/groups/[name]/settings.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../hooks";
 import { GroupSettings, SettingStates } from "../../../constants/setting";
 import SettingsForm from "../../../components/Settings/Form";
-import { settingValueByName } from "../../../utils/setting";
+import { settingValue } from "../../../utils/setting";
 import { GroupPermissions } from "../../../constants/role";
 
 const Settings = () => {
@@ -34,8 +34,7 @@ const Settings = () => {
   const isNoAdmin = (): boolean => {
     return (
       !anyUnsavedSettings() &&
-      settingValueByName(GroupSettings.NoAdmin, groupSettings) ===
-        SettingStates.On
+      settingValue(GroupSettings.NoAdmin, groupSettings) === SettingStates.On
     );
   };
 

--- a/src/pages/motions/[id].tsx
+++ b/src/pages/motions/[id].tsx
@@ -77,8 +77,7 @@ const Show = () => {
   }, [commentsRes.data]);
 
   useEffect(() => {
-    if (!votes.find((vote) => vote.body) && comments.length && !tabFromGlobal)
-      setTab(1);
+    if (!votes.find((vote) => vote.body) && !tabFromGlobal) setTab(1);
   }, [votes, comments]);
 
   useEffect(() => {

--- a/src/pages/votes/[id]/edit.tsx
+++ b/src/pages/votes/[id]/edit.tsx
@@ -14,7 +14,7 @@ import { noCache } from "../../../utils/apollo";
 import { useSettingsByGroupId } from "../../../hooks";
 import { GroupSettings } from "../../../constants/setting";
 import { VotingTypes } from "../../../constants/vote";
-import { settingValueByName } from "../../../utils/setting";
+import { settingValue } from "../../../utils/setting";
 import Messages from "../../../utils/messages";
 import { TypeNames } from "../../../constants/common";
 
@@ -31,7 +31,7 @@ const Edit = () => {
 
   useEffect(() => {
     setIsModelOfConsensus(
-      settingValueByName(GroupSettings.VotingType, groupSettings) ===
+      settingValue(GroupSettings.VotingType, groupSettings) ===
         VotingTypes.Consensus
     );
   }, [groupSettings]);

--- a/src/prisma/migrations/20210926162718_removed_unused_columns/migration.sql
+++ b/src/prisma/migrations/20210926162718_removed_unused_columns/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `description` on the `Permission` table. All the data in the column will be lost.
+  - You are about to drop the column `verified` on the `Vote` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Permission" DROP COLUMN "description";
+
+-- AlterTable
+ALTER TABLE "Vote" DROP COLUMN "verified";

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -31,7 +31,6 @@ model Vote {
   body           String?
   flipState      String?
   consensusState String?
-  verified       Boolean  @default(false)
   user           User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId         Int?
   motion         Motion?  @relation(fields: [motionId], references: [id])
@@ -218,7 +217,6 @@ model RoleMember {
 model Permission {
   id          Int      @id @default(autoincrement())
   name        String
-  description String
   enabled     Boolean  @default(false)
   role        Role?    @relation(fields: [roleId], references: [id])
   roleId      Int?

--- a/src/styles/Role/Role.module.scss
+++ b/src/styles/Role/Role.module.scss
@@ -39,13 +39,10 @@
   margin-bottom: 24px;
 }
 
-.permissionName {
-  margin-bottom: 6px;
-}
-
 .permissionDescription {
   font-size: 12px;
   color: $gray;
+  margin-top: 6px;
 }
 
 .deleteButton {

--- a/src/typings/motion.d.ts
+++ b/src/typings/motion.d.ts
@@ -17,4 +17,8 @@ interface ActionData {
   groupImagePath?: string;
   groupImage?: File;
   groupSettings?: SettingInput[];
+  groupRole?: ProposedRole;
+  groupRolePermissions?: InitialPermission[];
+  groupRoleId?: string;
+  userId?: string;
 }

--- a/src/typings/role.d.ts
+++ b/src/typings/role.d.ts
@@ -9,7 +9,6 @@ interface ClientPermission {
   id: string;
   roleId: string;
   name: string;
-  description: string;
   enabled: boolean;
   createdAt: string;
 }
@@ -19,4 +18,14 @@ interface ClientRoleMember {
   roleId: string;
   userId: string;
   createdAt: Date;
+}
+
+interface InitialPermission {
+  name: string;
+  enabled: boolean;
+}
+
+interface ProposedRole {
+  name: string;
+  color: string;
 }

--- a/src/utils/role.ts
+++ b/src/utils/role.ts
@@ -1,10 +1,42 @@
 import Messages from "./messages";
-import { ModelNames } from "../constants/common";
 import { GlobalPermissions, GroupPermissions } from "../constants/role";
 
-export const permissionDescription = (name: string) => {
-  const descriptions = Messages.roles.permissions.descriptions;
+export const permissionDisplayName = (name: string): string => {
+  const displayNames = Messages.roles.permissions.names;
+  switch (name) {
+    case GlobalPermissions.CreateInvites:
+      return displayNames.createInvites();
+    case GlobalPermissions.ManageInvites:
+      return displayNames.createInvites();
+    case GlobalPermissions.ManageComments:
+    case GroupPermissions.ManageComments:
+      return displayNames.manageComments();
+    case GlobalPermissions.ManagePosts:
+    case GroupPermissions.ManagePosts:
+      return displayNames.managePosts();
+    case GlobalPermissions.ManageRoles:
+      return displayNames.manageRoles();
+    case GlobalPermissions.ManageUsers:
+      return displayNames.manageUsers();
+    case GroupPermissions.ManageRoles:
+      return displayNames.manageRoles();
+    case GroupPermissions.AcceptMemberRequests:
+      return displayNames.acceptMemberRequests();
+    case GroupPermissions.DeleteGroup:
+      return displayNames.deleteGroup();
+    case GroupPermissions.EditGroup:
+      return displayNames.editGroup();
+    case GroupPermissions.KickMembers:
+      return displayNames.kickGroupMembers();
+    case GroupPermissions.ManageSettings:
+      return displayNames.manageSettings();
+    default:
+      return "";
+  }
+};
 
+export const permissionDescription = (name: string): string => {
+  const descriptions = Messages.roles.permissions.descriptions;
   switch (name) {
     case GlobalPermissions.CreateInvites:
       return descriptions.createInvites();
@@ -12,16 +44,15 @@ export const permissionDescription = (name: string) => {
       return descriptions.createInvites();
     case GlobalPermissions.ManageComments:
     case GroupPermissions.ManageComments:
-      return descriptions.manageItems(ModelNames.Comment);
+      return descriptions.manageComments();
     case GlobalPermissions.ManagePosts:
     case GroupPermissions.ManagePosts:
-      return descriptions.manageItems(ModelNames.Post);
+      return descriptions.managePosts();
     case GlobalPermissions.ManageRoles:
     case GroupPermissions.ManageRoles:
       return descriptions.manageRoles();
     case GlobalPermissions.ManageUsers:
       return descriptions.manageUsers();
-
     case GroupPermissions.AcceptMemberRequests:
       return descriptions.acceptMemberRequests();
     case GroupPermissions.DeleteGroup:
@@ -32,5 +63,7 @@ export const permissionDescription = (name: string) => {
       return descriptions.kickGroupMembers();
     case GroupPermissions.ManageSettings:
       return descriptions.manageGroupSettings();
+    default:
+      return "";
   }
 };

--- a/src/utils/setting.ts
+++ b/src/utils/setting.ts
@@ -3,7 +3,7 @@ import { VotingTypes } from "../constants/vote";
 import { displayName } from "./items";
 import Messages from "./messages";
 
-export const descriptionByName = (name: string) => {
+export const settingDescription = (name: string) => {
   const descriptions = Messages.settings.groups.descriptions;
   switch (name) {
     case GroupSettings.NoAdmin:
@@ -20,6 +20,26 @@ export const descriptionByName = (name: string) => {
       return descriptions.xToPass();
     case GroupSettings.XToBlock:
       return descriptions.xToBlock();
+  }
+};
+
+export const settingDisplayName = (name: string) => {
+  const displayNames = Messages.settings.groups.names;
+  switch (name) {
+    case GroupSettings.NoAdmin:
+      return displayNames.noAdmin();
+    case GroupSettings.VotingType:
+      return displayNames.votingType();
+    case GroupSettings.RatificationThreshold:
+      return displayNames.ratificationThreshold();
+    case GroupSettings.ReservationsLimit:
+      return displayNames.reservationsLimit();
+    case GroupSettings.StandAsidesLimit:
+      return displayNames.standAsidesLimit();
+    case GroupSettings.XToPass:
+      return displayNames.xToPass();
+    case GroupSettings.XToBlock:
+      return displayNames.xToBlock();
   }
 };
 
@@ -49,7 +69,7 @@ export const canShowSetting = (name: string, votingType: string): boolean => {
   return true;
 };
 
-export const settingValueByName = (
+export const settingValue = (
   name: string,
   settings: ClientSetting[]
 ): string => {


### PR DESCRIPTION
This PR implements basic functionality for motions to create, change, or assign group roles.

#### Changes
- Added the following components
  - `GroupRolesTab`
- Added the following constants
  - `INITIAL_GLOBAL_PERMISSIONS`
  - `INITIAL_GROUP_PERMISSIONS`
  - `INITIAL_GLOBAL_ADMIN_PERMISSIONS`
  - `INITIAL_GROUP_ADMIN_PERMISSIONS`
- Removed the following columns from DB schema
  - `verified` in `Votes`
  - `description` in `Permissions`
- Added the following utils
  - `permissionDisplayName`
  - `settingDisplayName`
- Turned on `no-unnecessary-type-assertion` ESLint rule