### PR TITLE
Roles info added to group's About page

### DIFF
--- a/src/components/Motions/ActionData.tsx
+++ b/src/components/Motions/ActionData.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import { Typography } from "@material-ui/core";
-import { displayName, displaySettingValue } from "../../utils/clientIndex";
+import {
+  displaySettingValue,
+  permissionDisplayName,
+  settingDisplayName,
+} from "../../utils/clientIndex";
 import { ResourcePaths } from "../../constants/common";
 import { GroupAspects } from "../../constants/group";
 import { ActionTypes } from "../../constants/motion";
@@ -63,7 +67,7 @@ const ActionData = ({ id, action, actionData }: ActionDataProps) => {
 
         {actionData.groupRolePermissions.map((permission) => (
           <Typography key={permission.name}>
-            {`• ${displayName(permission.name)}: `}
+            {`• ${permissionDisplayName(permission.name)}: `}
             {permission.enabled
               ? Messages.roles.permissions.states.enabled()
               : Messages.roles.permissions.states.disabled()}
@@ -85,7 +89,7 @@ const ActionData = ({ id, action, actionData }: ActionDataProps) => {
           • Role: <RoleName roleId={actionData.groupRoleId} />
         </Typography>
         <Typography>
-          • Member: <UserName userId={actionData.userId} noLoader />
+          • Member: <UserName userId={actionData.userId} />
         </Typography>
       </div>
     );
@@ -97,7 +101,7 @@ const ActionData = ({ id, action, actionData }: ActionDataProps) => {
 
         {actionData.groupSettings.map((setting) => (
           <Typography key={setting.id}>
-            • {displayName(setting.name)}: {displaySettingValue(setting)}
+            • {settingDisplayName(setting.name)}: {displaySettingValue(setting)}
           </Typography>
         ))}
       </div>

--- a/src/components/Roles/Name.tsx
+++ b/src/components/Roles/Name.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
 import { ROLE } from "../../apollo/client/queries";
 import { noCache } from "../../utils/apollo";
+import Messages from "../../utils/messages";
 
 const RoleName = ({ roleId }: { roleId: string }) => {
   const [role, setRole] = useState<ClientRole>();
@@ -14,6 +15,7 @@ const RoleName = ({ roleId }: { roleId: string }) => {
     if (roleRes.data) setRole(roleRes.data.role);
   }, [roleRes.data]);
 
+  if (roleRes.loading) return <>{Messages.states.loading()}</>;
   return <span style={{ color: role?.color }}>{role?.name}</span>;
 };
 

--- a/src/components/Roles/Role.tsx
+++ b/src/components/Roles/Role.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Avatar, LinearProgress } from "@material-ui/core";
 import { ArrowForwardIos, Person } from "@material-ui/icons";
 
 import Messages from "../../utils/messages";
 import styles from "../../styles/Role/Role.module.scss";
-import { ROLE_MEMBERS } from "../../apollo/client/queries";
-import { useQuery } from "@apollo/client";
-import { noCache } from "../../utils/apollo";
 import { BLACK } from "../../styles/Shared/theme";
 import { NavigationPaths, ResourcePaths } from "../../constants/common";
+import { useMembersByRoleId } from "../../hooks";
 
 interface Props {
   role: ClientRole;
@@ -18,44 +15,34 @@ interface Props {
 
 const Role = ({ role, group }: Props) => {
   const { id, name, color } = role;
-  const [members, setMembers] = useState<ClientRoleMember[]>([]);
-  const membersRes = useQuery(ROLE_MEMBERS, {
-    variables: {
-      roleId: id,
-    },
-    ...noCache,
-  });
+  const [members, _, membersLoading] = useMembersByRoleId(id);
   const editRolePath = `${ResourcePaths.Roles}${id}${NavigationPaths.Edit}`;
   const editGroupRolePath = `${ResourcePaths.Group}${group?.name}${editRolePath}`;
 
-  useEffect(() => {
-    if (membersRes.data) setMembers(membersRes.data.roleMembers);
-  }, [membersRes.data]);
+  if (membersLoading) return <LinearProgress />;
 
-  if (role && !membersRes.loading)
-    return (
-      <Link href={group ? editGroupRolePath : editRolePath} passHref>
-        <a className={styles.role}>
-          <div className={styles.link}>
-            <Avatar
-              style={{
-                backgroundColor: color,
-                color: BLACK,
-              }}
-            />
-            <div className={styles.info}>
-              <div className={styles.name}>{name}</div>
-              <div className={styles.members}>
-                <Person className={styles.icon} style={{ fontSize: 18 }} />
-                {Messages.roles.members.nMembers(members.length)}
-              </div>
+  return (
+    <Link href={group ? editGroupRolePath : editRolePath} passHref>
+      <a className={styles.role}>
+        <div className={styles.link}>
+          <Avatar
+            style={{
+              backgroundColor: color,
+              color: BLACK,
+            }}
+          />
+          <div className={styles.info}>
+            <div className={styles.name}>{name}</div>
+            <div className={styles.members}>
+              <Person className={styles.icon} style={{ fontSize: 18 }} />
+              {Messages.roles.members.nMembers(members.length)}
             </div>
           </div>
-          <ArrowForwardIos className={styles.icon} style={{ marginTop: 12 }} />
-        </a>
-      </Link>
-    );
-  return <LinearProgress />;
+        </div>
+        <ArrowForwardIos className={styles.icon} style={{ marginTop: 12 }} />
+      </a>
+    </Link>
+  );
 };
 
 export default Role;

--- a/src/components/Roles/RoleCompact.tsx
+++ b/src/components/Roles/RoleCompact.tsx
@@ -1,0 +1,82 @@
+import { ChangeEvent } from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  LinearProgress,
+  Typography,
+} from "@material-ui/core";
+import { AccountCircle, ExpandMore } from "@material-ui/icons";
+import { useMembersByRoleId, usePermissionsByRoleId } from "../../hooks";
+import { permissionDisplayName } from "../../utils/clientIndex";
+import Messages from "../../utils/messages";
+import UserName from "../Users/Name";
+
+interface Props {
+  role: ClientRole;
+  expanded: string | false;
+  handleClick: (
+    roleId: string
+  ) => (event: ChangeEvent<any>, expanded: boolean) => void;
+}
+
+const RoleCompact = ({ role, expanded, handleClick }: Props) => {
+  const { id, name, color } = role;
+  const [permissions, _setPermissions, permissionsLoading] =
+    usePermissionsByRoleId(id, Boolean(expanded));
+  const [members, _setMembers, membersLoading] = useMembersByRoleId(
+    id,
+    Boolean(expanded)
+  );
+  const enabledPermissions = permissions.filter(({ enabled }) => enabled);
+
+  return (
+    <Accordion expanded={expanded === id} onChange={handleClick(id)}>
+      <AccordionSummary expandIcon={<ExpandMore color="primary" />}>
+        <Typography style={{ color }}>
+          <AccountCircle style={{ marginBottom: -6 }} />
+          {" " + name}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails style={{ display: "block" }}>
+        {membersLoading || permissionsLoading ? (
+          <LinearProgress />
+        ) : (
+          <>
+            {Boolean(members.length) && (
+              <>
+                <Typography>{Messages.roles.tabs.members()}</Typography>
+                {members.map(({ id, userId }) => (
+                  <Typography key={id}>
+                    • <UserName userId={userId} />
+                  </Typography>
+                ))}
+              </>
+            )}
+
+            {Boolean(enabledPermissions.length && members.length) && (
+              <div style={{ height: 12 }}></div>
+            )}
+
+            {Boolean(enabledPermissions.length) && (
+              <>
+                <Typography>{Messages.roles.tabs.permissions()}</Typography>
+                {enabledPermissions.map(({ name }) => (
+                  <Typography key={name}>{`• ${permissionDisplayName(
+                    name
+                  )}`}</Typography>
+                ))}
+              </>
+            )}
+
+            {!enabledPermissions.length && !members.length && (
+              <Typography>{Messages.roles.noMembersOrPermissions()}</Typography>
+            )}
+          </>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default RoleCompact;

--- a/src/components/Users/Name.tsx
+++ b/src/components/Users/Name.tsx
@@ -1,14 +1,9 @@
-import { LinearProgress } from "@material-ui/core";
 import { useUserById } from "../../hooks";
+import Messages from "../../utils/messages";
 
-interface Props {
-  userId: string;
-  noLoader?: boolean;
-}
-
-const UserName = ({ userId, noLoader }: Props) => {
+const UserName = ({ userId }: { userId: string }) => {
   const [user, _, userLoading] = useUserById(userId);
-  if (userLoading && !noLoader) return <LinearProgress />;
+  if (userLoading) return <>{Messages.states.loading()}</>;
   return <>{user?.name}</>;
 };
 

--- a/src/hooks/role.ts
+++ b/src/hooks/role.ts
@@ -3,9 +3,91 @@ import { useLazyQuery } from "@apollo/client";
 import {
   HAS_PERMISSION_BY_GROUP_ID,
   HAS_PERMISSION_GLOBALLY,
+  PERMISSIONS_BY_ROLE_ID,
+  ROLES_BY_GROUP_ID,
+  ROLE_MEMBERS,
 } from "../apollo/client/queries";
 import { noCache } from "../utils/apollo";
 import { useCurrentUser } from "./user";
+
+export const usePermissionsByRoleId = (
+  roleId: string | string[] | undefined,
+  greenLight = true,
+  callDep?: any
+): [ClientPermission[], (permissions: ClientPermission[]) => void, boolean] => {
+  const [permissions, setPermissions] = useState<ClientPermission[]>([]);
+  const [getPermissionsRes, permissionsRes] = useLazyQuery(
+    PERMISSIONS_BY_ROLE_ID,
+    noCache
+  );
+
+  useEffect(() => {
+    if (roleId && greenLight) {
+      getPermissionsRes({
+        variables: {
+          roleId,
+        },
+      });
+    }
+  }, [roleId, greenLight, callDep]);
+
+  useEffect(() => {
+    if (permissionsRes.data)
+      setPermissions(permissionsRes.data.permissionsByRoleId);
+  }, [permissionsRes.data]);
+
+  return [permissions, setPermissions, permissionsRes.loading];
+};
+
+export const useMembersByRoleId = (
+  roleId: string | string[] | undefined,
+  greenLight = true,
+  callDep?: any
+): [ClientRoleMember[], (members: ClientRoleMember[]) => void, boolean] => {
+  const [members, setMembers] = useState<ClientRoleMember[]>([]);
+  const [getMembersRes, membersRes] = useLazyQuery(ROLE_MEMBERS, noCache);
+
+  useEffect(() => {
+    if (roleId && greenLight) {
+      getMembersRes({
+        variables: {
+          roleId,
+        },
+      });
+    }
+  }, [roleId, greenLight, callDep]);
+
+  useEffect(() => {
+    if (membersRes.data) setMembers(membersRes.data.roleMembers);
+  }, [membersRes.data]);
+
+  return [members, setMembers, membersRes.loading];
+};
+
+export const useRolesByGroupId = (
+  groupId: string | string[] | undefined,
+  greenLight = true,
+  callDep?: any
+): [ClientRole[], (roles: ClientRole[]) => void, boolean] => {
+  const [roles, setRoles] = useState<ClientRole[]>([]);
+  const [getRolesRes, rolesRes] = useLazyQuery(ROLES_BY_GROUP_ID, noCache);
+
+  useEffect(() => {
+    if (groupId && greenLight) {
+      getRolesRes({
+        variables: {
+          groupId,
+        },
+      });
+    }
+  }, [groupId, greenLight, callDep]);
+
+  useEffect(() => {
+    if (rolesRes.data) setRoles(rolesRes.data.rolesByGroupId);
+  }, [rolesRes.data]);
+
+  return [roles, setRoles, rolesRes.loading];
+};
 
 export const useHasPermissionGlobally = (
   name: string,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -394,6 +394,8 @@ const en = {
     groupRoles: () => "Group Roles",
     serverRoles: () => "Server Roles",
     noRoles: () => "No roles have been created for this server yet.",
+    noMembersOrPermissions: () =>
+      "This role has no permissions enabled and no assigned members.",
   },
 
   invites: {

--- a/src/pages/groups/[name]/roles/index.tsx
+++ b/src/pages/groups/[name]/roles/index.tsx
@@ -1,14 +1,15 @@
-import { useEffect, useState } from "react";
-import { useLazyQuery } from "@apollo/client";
+import { useEffect } from "react";
 import { CircularProgress, Card, Typography } from "@material-ui/core";
 import { useRouter } from "next/router";
 
 import Role from "../../../../components/Roles/Role";
-import { ROLES_BY_GROUP_ID } from "../../../../apollo/client/queries";
 import RoleForm from "../../../../components/Roles/Form";
-import { noCache } from "../../../../utils/apollo";
 import Messages from "../../../../utils/messages";
-import { useGroupByName, useHasPermissionByGroupId } from "../../../../hooks";
+import {
+  useGroupByName,
+  useHasPermissionByGroupId,
+  useRolesByGroupId,
+} from "../../../../hooks";
 import { GroupPermissions } from "../../../../constants/role";
 import { breadcrumbsVar } from "../../../../apollo/client/localState";
 import { ResourcePaths, TypeNames } from "../../../../constants/common";
@@ -16,24 +17,12 @@ import { ResourcePaths, TypeNames } from "../../../../constants/common";
 const GroupRolesIndex = () => {
   const { query } = useRouter();
   const [group, _, groupLoading] = useGroupByName(query.name);
-  const [roles, setRoles] = useState<ClientRole[]>([]);
-  const [getRolesRes, rolesRes] = useLazyQuery(ROLES_BY_GROUP_ID, noCache);
+  const [roles, setRoles, rolesLoading] = useRolesByGroupId(group?.id);
   const [canManageRoles, canManageRolesLoading] = useHasPermissionByGroupId(
     GroupPermissions.ManageRoles,
     group?.id,
     roles
   );
-
-  useEffect(() => {
-    if (group)
-      getRolesRes({
-        variables: { groupId: group.id },
-      });
-  }, [group]);
-
-  useEffect(() => {
-    if (rolesRes.data) setRoles(rolesRes.data.rolesByGroupId);
-  }, [rolesRes.data]);
 
   useEffect(() => {
     if (group && canManageRoles)
@@ -53,7 +42,7 @@ const GroupRolesIndex = () => {
     };
   }, [group, canManageRoles]);
 
-  if (canManageRolesLoading || groupLoading || rolesRes.loading)
+  if (canManageRolesLoading || groupLoading || rolesLoading)
     return <CircularProgress />;
   if (!group)
     return <Typography>{Messages.items.notFound(TypeNames.Group)}</Typography>;
@@ -62,7 +51,6 @@ const GroupRolesIndex = () => {
   return (
     <>
       <RoleForm roles={roles} setRoles={setRoles} group={group} />
-
       <Card>
         {roles
           .slice()

--- a/src/styles/Shared/theme.ts
+++ b/src/styles/Shared/theme.ts
@@ -225,6 +225,30 @@ const muiTheme = createTheme({
       },
     },
 
+    MuiAccordion: {
+      root: {
+        "&:before": {
+          backgroundColor: globalTheme.palette.secondary.main,
+        },
+      },
+      rounded: {
+        "&:first-child": {
+          borderTopLeftRadius: 8,
+          borderTopRightRadius: 8,
+        },
+        "&:last-child": {
+          borderBottomLeftRadius: 8,
+          borderBottomRightRadius: 8,
+        },
+      },
+    },
+
+    MuiAccordionDetails: {
+      root: {
+        paddingBottom: 32,
+      },
+    },
+
     MuiCircularProgress: {
       colorPrimary: {
         color: globalTheme.palette.primary.contrastText,


### PR DESCRIPTION
This PR adds info about group roles to group's About pages, such as enabled permissions and members assigned to the role.

#### Changes
- Added the following hooks
  - `useRolesByGroupId`
  - `useMembersByRoleId`
  - `usePermissionsByRoleId`