### PR TITLE
Remove "Praxis API" name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Praxis API
+# Contributing to Praxis
 
 We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Praxis API
+## Praxis
 
 Praxis is an open source social networking site. Proposals are the main focus and come with a wide variety of voting features, with consensus as the default. Create a group and set it to no-admin, allowing group members to create proposals and democratically decide on name, settings, roles, or planning of real world events.
 
@@ -75,4 +75,4 @@ $ npx husky install && npx husky add .husky/pre-commit "yarn lint-staged"
 
 ## Contributions
 
-Praxis API is open to contributions. Please read [CONTRIBUTING.md](https://github.com/praxis-project/praxis-api/blob/main/CONTRIBUTING.md) for more details.
+Praxis is open to contributions. Please read [CONTRIBUTING.md](https://github.com/praxis-project/praxis-api/blob/main/CONTRIBUTING.md) for more details.

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,9 +17,9 @@ const bootstrap = async () => {
   app.use(cookieParser());
 
   const config = new DocumentBuilder()
-    .setTitle("Praxis API")
+    .setTitle("Praxis")
     .setDescription(
-      "Social networking API built with NestJS, Apollo Server, and TypeORM"
+      "Social networking API built with NestJS, GraphQL, and TypeORM"
     )
     .setVersion("1.0")
     .build();


### PR DESCRIPTION
Removes instances of "Praxis API" name where the distinction isn't necessary.

Related PR: https://github.com/praxis-project/praxis-ui/pull/6