### PR TITLE
Convert to one to many relation for proposal action images

### DIFF
--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -25,6 +25,7 @@ import { DropGroupMemberEntityTable1681010509841 } from "./migrations/1681010509
 import { AddRoleMemberLinkTable1681172948650 } from "./migrations/1681172948650-AddRoleMemberLinkTable";
 import { DropRoleMemberEntityTable1681173025669 } from "./migrations/1681173025669-DropRoleMemberEntityTable";
 import { AddProposalActionRoleTable1684893300206 } from "./migrations/1684893300206-AddProposalActionRoleTable";
+import { AddProposalActionImagesConstraint1685201083917 } from "./migrations/1685201083917-AddProposalActionImagesConstraint";
 
 config();
 
@@ -57,6 +58,7 @@ export default new DataSource({
     AddFollowTable1679778147216,
     AddGroupMemberLinkTable1681010227367,
     AddLikeTable1679157357262,
+    AddProposalActionImagesConstraint1685201083917,
     AddProposalActionRoleTable1684893300206,
     AddRoleMemberLinkTable1681172948650,
     AddServerInviteTable1677339785709,

--- a/src/database/migrations/1685201083917-AddProposalActionImagesConstraint.ts
+++ b/src/database/migrations/1685201083917-AddProposalActionImagesConstraint.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddProposalActionImagesConstraint1685201083917
+  implements MigrationInterface
+{
+  name = "AddProposalActionImagesConstraint1685201083917";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "image" DROP CONSTRAINT "FK_e2a8d2eb051eb21b6715f6d21b2"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "image" DROP CONSTRAINT "REL_e2a8d2eb051eb21b6715f6d21b"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "image" ADD CONSTRAINT "FK_e2a8d2eb051eb21b6715f6d21b2" FOREIGN KEY ("proposalActionId") REFERENCES "proposal_action"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "image" DROP CONSTRAINT "FK_e2a8d2eb051eb21b6715f6d21b2"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "image" ADD CONSTRAINT "REL_e2a8d2eb051eb21b6715f6d21b" UNIQUE ("proposalActionId")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "image" ADD CONSTRAINT "FK_e2a8d2eb051eb21b6715f6d21b2" FOREIGN KEY ("proposalActionId") REFERENCES "proposal_action"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+}

--- a/src/images/models/image.model.ts
+++ b/src/images/models/image.model.ts
@@ -3,9 +3,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  JoinColumn,
   ManyToOne,
-  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
@@ -67,14 +65,9 @@ export class Image {
   proposalId: number;
 
   @Field(() => ProposalAction)
-  @OneToOne(
-    () => ProposalAction,
-    (proposalAction) => proposalAction.groupCoverPhoto,
-    {
-      onDelete: "CASCADE",
-    }
-  )
-  @JoinColumn()
+  @ManyToOne(() => ProposalAction, (proposalAction) => proposalAction.images, {
+    onDelete: "CASCADE",
+  })
   proposalAction: ProposalAction;
 
   @Column({ nullable: true })

--- a/src/proposals/pipes/update-proposal-validation.pipe.ts
+++ b/src/proposals/pipes/update-proposal-validation.pipe.ts
@@ -1,5 +1,6 @@
 import { ArgumentMetadata, Injectable, PipeTransform } from "@nestjs/common";
 import { ValidationError } from "apollo-server-express";
+import { ImageTypes } from "../../images/images.service";
 import { VotesService } from "../../votes/votes.service";
 import { UpdateProposalInput } from "../models/update-proposal.input";
 import { ProposalActionType } from "../proposals.constants";
@@ -42,9 +43,12 @@ export class UpdateProposalValidationPipe implements PipeTransform {
       !groupCoverPhoto
     ) {
       const proposal = await this.proposalsService.getProposal(id, [
-        "action.groupCoverPhoto",
+        "action.images",
       ]);
-      if (proposal.action.groupCoverPhoto) {
+      const alreadyExisting = proposal.images.some(
+        (image) => image.imageType === ImageTypes.CoverPhoto
+      );
+      if (alreadyExisting) {
         return;
       }
       throw new ValidationError(

--- a/src/proposals/proposal-actions/models/proposal-action.model.ts
+++ b/src/proposals/proposal-actions/models/proposal-action.model.ts
@@ -4,6 +4,7 @@ import {
   CreateDateColumn,
   Entity,
   JoinColumn,
+  OneToMany,
   OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
@@ -32,10 +33,10 @@ export class ProposalAction {
   groupDescription?: string;
 
   @Field(() => Image, { nullable: true })
-  @OneToOne(() => Image, (image) => image.proposalAction, {
-    cascade: true,
-  })
   groupCoverPhoto?: Image;
+
+  @OneToMany(() => Image, (image) => image.proposalAction)
+  images: Image[];
 
   @Field(() => ProposalActionRole, { nullable: true })
   @OneToOne(

--- a/src/proposals/proposal-actions/proposal-actions.resolver.ts
+++ b/src/proposals/proposal-actions/proposal-actions.resolver.ts
@@ -1,10 +1,11 @@
 import { Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { Image } from "../../images/models/image.model";
 import { Proposal } from "../models/proposal.model";
 import { ProposalsService } from "../proposals.service";
-import { ProposalActionRole } from "./proposal-action-roles/models/proposal-action-role.model";
 import { ProposalAction } from "./models/proposal-action.model";
-import { ProposalActionsService } from "./proposal-actions.service";
+import { ProposalActionRole } from "./proposal-action-roles/models/proposal-action-role.model";
 import { ProposalActionRolesService } from "./proposal-action-roles/proposal-action-roles.service";
+import { ProposalActionsService } from "./proposal-actions.service";
 
 @Resolver(() => ProposalAction)
 export class ProposalActionsResolver {

--- a/src/proposals/proposal-actions/proposal-actions.service.ts
+++ b/src/proposals/proposal-actions/proposal-actions.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { FileUpload } from "graphql-upload";
 import { FindOptionsWhere, In, Repository } from "typeorm";
 import { saveImage } from "../../images/image.utils";
-import { ImagesService } from "../../images/images.service";
+import { ImagesService, ImageTypes } from "../../images/images.service";
 import { ProposalAction } from "./models/proposal-action.model";
 
 @Injectable()
@@ -28,9 +28,12 @@ export class ProposalActionsService {
 
   async getProposedGroupCoverPhoto(proposalActionId: number) {
     const action = await this.getProposalAction({ id: proposalActionId }, [
-      "groupCoverPhoto",
+      "images",
     ]);
-    return action?.groupCoverPhoto;
+    const groupCoverPhoto = action?.images.find(
+      (image) => image.imageType === ImageTypes.CoverPhoto
+    );
+    return groupCoverPhoto;
   }
 
   async getProposalActionsByBatch(proposalIds: number[]) {

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -172,9 +172,9 @@ export class ProposalsService {
 
   async implementProposal(proposalId: number) {
     const {
-      action: { id, actionType, groupCoverPhoto, groupDescription, groupName },
+      action: { id, actionType, groupDescription, groupName },
       groupId,
-    } = await this.getProposal(proposalId, ["action.groupCoverPhoto"]);
+    } = await this.getProposal(proposalId, ["action"]);
 
     if (actionType === ProposalActionType.ChangeName) {
       await this.groupsService.updateGroup({ id: groupId, name: groupName });
@@ -189,15 +189,19 @@ export class ProposalsService {
       return;
     }
 
-    if (actionType === ProposalActionType.ChangeCoverPhoto && groupCoverPhoto) {
+    if (actionType === ProposalActionType.ChangeCoverPhoto) {
       const currentCoverPhoto = await this.imagesService.getImage({
         imageType: ImageTypes.CoverPhoto,
         groupId,
       });
-      if (!currentCoverPhoto) {
+      const newCoverPhoto =
+        await this.proposalActionsService.getProposedGroupCoverPhoto(id);
+
+      if (!currentCoverPhoto || !newCoverPhoto) {
         throw new UserInputError("Could not find group cover photo");
       }
-      await this.imagesService.updateImage(groupCoverPhoto.id, { groupId });
+
+      await this.imagesService.updateImage(newCoverPhoto.id, { groupId });
       await this.imagesService.deleteImage({ id: currentCoverPhoto.id });
     }
 


### PR DESCRIPTION
Converts the one to one relation between `ProposalAction` and `Image` to one to many.

This will ensure that more proposal actions can be easily added later that also include images.