### PR TITLE
Fix group deletes

### DIFF
--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -26,6 +26,7 @@ import { AddRoleMemberLinkTable1681172948650 } from "./migrations/1681172948650-
 import { DropRoleMemberEntityTable1681173025669 } from "./migrations/1681173025669-DropRoleMemberEntityTable";
 import { AddProposalActionRoleTable1684893300206 } from "./migrations/1684893300206-AddProposalActionRoleTable";
 import { AddProposalActionImagesConstraint1685201083917 } from "./migrations/1685201083917-AddProposalActionImagesConstraint";
+import { AddProposalActionRoleCascadeDelete1685748700121 } from "./migrations/1685748700121-AddProposalActionRoleCascadeDelete";
 
 config();
 
@@ -59,6 +60,7 @@ export default new DataSource({
     AddGroupMemberLinkTable1681010227367,
     AddLikeTable1679157357262,
     AddProposalActionImagesConstraint1685201083917,
+    AddProposalActionRoleCascadeDelete1685748700121,
     AddProposalActionRoleTable1684893300206,
     AddRoleMemberLinkTable1681172948650,
     AddServerInviteTable1677339785709,

--- a/src/database/migrations/1685748700121-AddProposalActionRoleCascadeDelete.ts
+++ b/src/database/migrations/1685748700121-AddProposalActionRoleCascadeDelete.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddProposalActionRoleCascadeDelete1685748700121
+  implements MigrationInterface
+{
+  name = "AddProposalActionRoleCascadeDelete1685748700121";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "proposal_action_role" DROP CONSTRAINT "FK_a5582c00ad2e43a5391f6cdb97b"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "proposal_action_role" ADD CONSTRAINT "FK_a5582c00ad2e43a5391f6cdb97b" FOREIGN KEY ("roleId") REFERENCES "role"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "proposal_action_role" DROP CONSTRAINT "FK_a5582c00ad2e43a5391f6cdb97b"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "proposal_action_role" ADD CONSTRAINT "FK_a5582c00ad2e43a5391f6cdb97b" FOREIGN KEY ("roleId") REFERENCES "role"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+}

--- a/src/proposals/proposal-actions/proposal-action-roles/models/proposal-action-role.model.ts
+++ b/src/proposals/proposal-actions/proposal-action-roles/models/proposal-action-role.model.ts
@@ -71,7 +71,10 @@ export class ProposalActionRole {
   proposalActionId: number;
 
   @Field(() => Role, { nullable: true })
-  @ManyToOne(() => Role, (role) => role.proposalActionRoles, { nullable: true })
+  @ManyToOne(() => Role, (role) => role.proposalActionRoles, {
+    nullable: true,
+    onDelete: "CASCADE",
+  })
   role?: Role;
 
   @Column({ nullable: true })


### PR DESCRIPTION
Resolves issues with group deletion.

Forgot to add `onDelete: "CASCADE"` for the `role` column in `ProposalActionRole`, which was preventing some groups from being deleted successfully.

The issue was only occurring for groups where a proposal to change a group role had been ratified.