### PR TITLE
Fix dataloader batching

### DIFF
--- a/src/dataloader/dataloader.service.ts
+++ b/src/dataloader/dataloader.service.ts
@@ -94,6 +94,14 @@ export class DataloaderService {
     };
   }
 
+  /**
+   * Creates a new dataloader with the given batch function and options.
+   *
+   * Passing a custom batch schedule function enables dataloader to work
+   * with asyncronous middleware.
+   *
+   * Source: https://dev.to/tsirlucas/integrating-dataloader-with-concurrent-react-53h1
+   */
   private _getDataLoader<K, V, C = K>(
     batchFn: DataLoader.BatchLoadFn<K, V>,
     options: DataLoader.Options<K, V, C> = {}

--- a/src/dataloader/dataloader.service.ts
+++ b/src/dataloader/dataloader.service.ts
@@ -168,10 +168,8 @@ export class DataloaderService {
   }
 
   private _createPostLikeCountLoader() {
-    return this._getDataLoader<number, number>(
-      async (postIds) =>
-        this.postsService.getLikesCountBatch(postIds as number[]),
-      { batchScheduleFn: (callback) => setTimeout(callback, 5) }
+    return this._getDataLoader<number, number>(async (postIds) =>
+      this.postsService.getLikesCountBatch(postIds as number[])
     );
   }
 

--- a/src/dataloader/dataloader.service.ts
+++ b/src/dataloader/dataloader.service.ts
@@ -5,10 +5,13 @@
 
 import { Injectable } from "@nestjs/common";
 import * as DataLoader from "dataloader";
+import { CommentsService } from "../comments/comments.service";
+import { EventsService } from "../events/events.service";
+import { Event } from "../events/models/event.model";
+import { GroupMemberRequestsService } from "../groups/group-member-requests/group-member-requests.service";
 import { GroupRolesService } from "../groups/group-roles/group-roles.service";
 import { GroupPermissions } from "../groups/group-roles/models/group-permissions.type";
 import { GroupsService } from "../groups/groups.service";
-import { GroupMemberRequestsService } from "../groups/group-member-requests/group-member-requests.service";
 import { Group } from "../groups/models/group.model";
 import { Image } from "../images/models/image.model";
 import { Like } from "../likes/models/like.model";
@@ -27,9 +30,6 @@ import {
   IsLikedByMeKey,
   MyGroupsKey,
 } from "./dataloader.types";
-import { EventsService } from "../events/events.service";
-import { Event } from "../events/models/event.model";
-import { CommentsService } from "../comments/comments.service";
 
 @Injectable()
 export class DataloaderService {
@@ -94,38 +94,49 @@ export class DataloaderService {
     };
   }
 
+  private _getDataLoader<K, V, C = K>(
+    batchFn: DataLoader.BatchLoadFn<K, V>,
+    options: DataLoader.Options<K, V, C> = {}
+  ) {
+    return new DataLoader<K, V, C>(batchFn, {
+      batchScheduleFn: (callback) => setTimeout(callback, 5),
+      ...options,
+    });
+  }
+
   // -------------------------------------------------------------------------
   // Proposals & Votes
   // -------------------------------------------------------------------------
 
   private _createProposalVotesLoader() {
-    return new DataLoader<number, Vote[]>(async (proposalIds) =>
+    return this._getDataLoader<number, Vote[]>(async (proposalIds) =>
       this.proposalsService.getProposalVotesBatch(proposalIds as number[])
     );
   }
 
   private _createProposalVoteCountLoader() {
-    return new DataLoader<number, number>(async (proposalIds) =>
+    return this._getDataLoader<number, number>(async (proposalIds) =>
       this.votesService.getVoteCountBatch(proposalIds as number[])
     );
   }
 
   private _createProposalImagesLoader() {
-    return new DataLoader<number, Image[]>(async (proposalIds) =>
+    return this._getDataLoader<number, Image[]>(async (proposalIds) =>
       this.proposalsService.getProposalImagesBatch(proposalIds as number[])
     );
   }
 
   private _createProposalActionsLoader() {
-    return new DataLoader<number, ProposalAction>(async (proposalActionIds) =>
-      this.proposalActionsService.getProposalActionsBatch(
-        proposalActionIds as number[]
-      )
+    return this._getDataLoader<number, ProposalAction>(
+      async (proposalActionIds) =>
+        this.proposalActionsService.getProposalActionsBatch(
+          proposalActionIds as number[]
+        )
     );
   }
 
   private _createProposalCommentCountLoader() {
-    return new DataLoader<number, number>(async (proposalIds) =>
+    return this._getDataLoader<number, number>(async (proposalIds) =>
       this.proposalsService.getProposalCommentCountBatch(
         proposalIds as number[]
       )
@@ -137,7 +148,7 @@ export class DataloaderService {
   // -------------------------------------------------------------------------
 
   private _createIsPostLikedByMeLoader() {
-    return new DataLoader<IsLikedByMeKey, boolean, number>(
+    return this._getDataLoader<IsLikedByMeKey, boolean, number>(
       async (keys) =>
         this.postsService.getIsLikedByMeBatch(keys as IsLikedByMeKey[]),
       { cacheKeyFn: (key) => key.postId }
@@ -145,25 +156,27 @@ export class DataloaderService {
   }
 
   private _createPostImagesLoader() {
-    return new DataLoader<number, Image[]>(async (postIds) =>
+    return this._getDataLoader<number, Image[]>(async (postIds) =>
       this.postsService.getPostImagesBatch(postIds as number[])
     );
   }
 
   private _createPostLikesLoader() {
-    return new DataLoader<number, Like[]>(async (postIds) =>
+    return this._getDataLoader<number, Like[]>(async (postIds) =>
       this.postsService.getPostLikesBatch(postIds as number[])
     );
   }
 
   private _createPostLikeCountLoader() {
-    return new DataLoader<number, number>(async (postIds) =>
-      this.postsService.getLikesCountBatch(postIds as number[])
+    return this._getDataLoader<number, number>(
+      async (postIds) =>
+        this.postsService.getLikesCountBatch(postIds as number[]),
+      { batchScheduleFn: (callback) => setTimeout(callback, 5) }
     );
   }
 
   private _createPostCommentCountLoader() {
-    return new DataLoader<number, number>(async (postIds) =>
+    return this._getDataLoader<number, number>(async (postIds) =>
       this.postsService.getPostCommentCountBatch(postIds as number[])
     );
   }
@@ -173,7 +186,7 @@ export class DataloaderService {
   // -------------------------------------------------------------------------
 
   private _createCommentImagesLoader() {
-    return new DataLoader<number, Image[]>(async (commentIds) =>
+    return this._getDataLoader<number, Image[]>(async (commentIds) =>
       this.commentsService.getCommentImagesBatch(commentIds as number[])
     );
   }
@@ -183,19 +196,19 @@ export class DataloaderService {
   // -------------------------------------------------------------------------
 
   private _createGroupsLoader() {
-    return new DataLoader<number, Group>(async (groupIds) =>
+    return this._getDataLoader<number, Group>(async (groupIds) =>
       this.groupsService.getGroupsBatch(groupIds as number[])
     );
   }
 
   private _createGroupCoverPhotosLoader() {
-    return new DataLoader<number, Image>(async (groupIds) =>
+    return this._getDataLoader<number, Image>(async (groupIds) =>
       this.groupsService.getCoverPhotosBatch(groupIds as number[])
     );
   }
 
   private _createMemberRequestCountLoader() {
-    return new DataLoader<number, number>(async (groupIds) =>
+    return this._getDataLoader<number, number>(async (groupIds) =>
       this.memberRequestsService.getGroupMemberRequestCountBatch(
         groupIds as number[]
       )
@@ -203,19 +216,19 @@ export class DataloaderService {
   }
 
   private _createGroupMemberCountLoader() {
-    return new DataLoader<number, number>(async (groupIds) =>
+    return this._getDataLoader<number, number>(async (groupIds) =>
       this.groupsService.getGroupMemberCountBatch(groupIds as number[])
     );
   }
 
   private _createGroupMembersLoader() {
-    return new DataLoader<number, User[]>(async (groupIds) =>
+    return this._getDataLoader<number, User[]>(async (groupIds) =>
       this.groupsService.getGroupMembersBatch(groupIds as number[])
     );
   }
 
   private _createIsJoinedByMeLoader() {
-    return new DataLoader<MyGroupsKey, boolean, number>(
+    return this._getDataLoader<MyGroupsKey, boolean, number>(
       async (keys) =>
         this.groupsService.isJoinedByMeBatch(keys as MyGroupsKey[]),
       { cacheKeyFn: (key) => key.groupId }
@@ -227,19 +240,19 @@ export class DataloaderService {
   // -------------------------------------------------------------------------
 
   private _createFollowerCountLoader() {
-    return new DataLoader<number, number>(async (userIds) =>
+    return this._getDataLoader<number, number>(async (userIds) =>
       this.usersService.getFollowerCountBatch(userIds as number[])
     );
   }
 
   private _createFollowingCountLoader() {
-    return new DataLoader<number, number>(async (userIds) =>
+    return this._getDataLoader<number, number>(async (userIds) =>
       this.usersService.getFollowingCountBatch(userIds as number[])
     );
   }
 
   private _createIsFollowedByMeLoader() {
-    return new DataLoader<IsFollowedByMeKey, boolean, number>(
+    return this._getDataLoader<IsFollowedByMeKey, boolean, number>(
       async (keys) =>
         this.usersService.getIsFollowedByMeBatch(keys as IsFollowedByMeKey[]),
       { cacheKeyFn: (key) => key.followedUserId }
@@ -247,13 +260,13 @@ export class DataloaderService {
   }
 
   private _createUsersLoader() {
-    return new DataLoader<number, User>(async (userIds) =>
+    return this._getDataLoader<number, User>(async (userIds) =>
       this.usersService.getUsersBatch(userIds as number[])
     );
   }
 
   private _createProfilePicturesLoader() {
-    return new DataLoader<number, Image>(async (userIds) =>
+    return this._getDataLoader<number, Image>(async (userIds) =>
       this.usersService.getProfilePicturesBatch(userIds as number[])
     );
   }
@@ -263,19 +276,19 @@ export class DataloaderService {
   // -------------------------------------------------------------------------
 
   private _createGroupRoleMemberCountLoader() {
-    return new DataLoader<number, number>(async (roleIds) =>
+    return this._getDataLoader<number, number>(async (roleIds) =>
       this.groupRolesService.getGroupRoleMemberCountBatch(roleIds as number[])
     );
   }
 
   private _createServerRoleMemberCountLoader() {
-    return new DataLoader<number, number>(async (roleIds) =>
+    return this._getDataLoader<number, number>(async (roleIds) =>
       this.serverRolesService.getServerRoleMemberCountBatch(roleIds as number[])
     );
   }
 
   private _createMyGroupPermissionsLoader() {
-    return new DataLoader<MyGroupsKey, GroupPermissions, number>(
+    return this._getDataLoader<MyGroupsKey, GroupPermissions, number>(
       async (keys) =>
         this.groupsService.getMyGroupPermissionsBatch(keys as MyGroupsKey[]),
       { cacheKeyFn: (key) => key.groupId }
@@ -287,25 +300,25 @@ export class DataloaderService {
   // -------------------------------------------------------------------------
 
   private _createEventCoverPhotosLoader() {
-    return new DataLoader<number, Image>(async (eventIds) =>
+    return this._getDataLoader<number, Image>(async (eventIds) =>
       this.eventsService.getCoverPhotosBatch(eventIds as number[])
     );
   }
 
   private _createEventsLoader() {
-    return new DataLoader<number, Event>(async (eventIds) =>
+    return this._getDataLoader<number, Event>(async (eventIds) =>
       this.eventsService.getEventsBatch(eventIds as number[])
     );
   }
 
   private _createInterestedCountLoader() {
-    return new DataLoader<number, number>(async (eventIds) =>
+    return this._getDataLoader<number, number>(async (eventIds) =>
       this.eventsService.getInterestedCountBatch(eventIds as number[])
     );
   }
 
   private _createGoingCountLoader() {
-    return new DataLoader<number, number>(async (eventIds) =>
+    return this._getDataLoader<number, number>(async (eventIds) =>
       this.eventsService.getGoingCountBatch(eventIds as number[])
     );
   }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -75,8 +75,6 @@ export class PostsService {
       .whereInIds(postIds)
       .getMany()) as PostWithLikeCount[];
 
-    console.log("getLikesCountBatch\n");
-
     return postIds.map((id) => {
       const post = posts.find((post: Post) => post.id === id);
       if (!post) {

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -75,6 +75,8 @@ export class PostsService {
       .whereInIds(postIds)
       .getMany()) as PostWithLikeCount[];
 
+    console.log("getLikesCountBatch\n");
+
     return postIds.map((id) => {
       const post = posts.find((post: Post) => post.id === id);
       if (!post) {


### PR DESCRIPTION
Dataloader batching was being disrupted by GraphQL Shield rules that were set for specific types and fields.

For more context about the problem:
- [NestJS - How can dataloaders be used in combination with GraphQL Shield? | SO](https://stackoverflow.com/questions/77034218/nestjs-how-can-dataloaders-be-used-in-combination-with-graphql-shield)
- [Dataloaders + GraphQL Shield with Apollo Server and NestJS | Reddit](https://www.reddit.com/r/graphql/comments/1686dmf/dataloaders_graphql_shield_with_apollo_server_and/)
- [Why does batching with a dataloader not work in a test? | SO](https://stackoverflow.com/questions/72103019/why-does-batching-with-a-dataloader-not-work-in-a-test)

Source for solution used:
- [Integrating Dataloader with Concurrent React | DEV](https://dev.to/tsirlucas/integrating-dataloader-with-concurrent-react-53h1)