### PR TITLE
Brand reload

### DIFF
--- a/view/components/Navigation/TopNav.tsx
+++ b/view/components/Navigation/TopNav.tsx
@@ -15,6 +15,7 @@ import { inDevToast } from '../../utils/shared.utils';
 import LevelOneHeading from '../Shared/LevelOneHeading';
 import Link from '../Shared/Link';
 import TopNavDesktop from './TopNavDesktop';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface Props {
   appBarProps?: AppBarProps;
@@ -23,6 +24,8 @@ interface Props {
 const TopNav = ({ appBarProps }: Props) => {
   const { t } = useTranslation();
   const isDesktop = useIsDesktop();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
   const theme = useTheme();
 
   const appBarStyles: SxProps = {
@@ -58,20 +61,20 @@ const TopNav = ({ appBarProps }: Props) => {
     ...(isDesktop ? desktopToolbarStyles : {}),
   };
 
-  const renderBrand = () => (
-    // TODO: Add reload functionality
-    // if (asPath === NavigationPaths.Home) {
-    //   return (
-    //     <LevelOneHeading onClick={() => reload()} sx={brandStyles}>
-    //       {t('brand')}
-    //     </LevelOneHeading>
-    //   );
-    // }
-
-    <Link href={NavigationPaths.Home}>
-      <LevelOneHeading sx={brandStyles}>{t('brand')}</LevelOneHeading>
-    </Link>
-  );
+  const renderBrand = () => {
+    if (pathname === NavigationPaths.Home) {
+      return (
+        <LevelOneHeading onClick={() => navigate(0)} sx={brandStyles}>
+          {t('brand')}
+        </LevelOneHeading>
+      );
+    }
+    return (
+      <Link href={NavigationPaths.Home}>
+        <LevelOneHeading sx={brandStyles}>{t('brand')}</LevelOneHeading>
+      </Link>
+    );
+  };
 
   return (
     <AppBar role="banner" position="fixed" sx={appBarStyles} {...appBarProps}>

--- a/view/components/Navigation/TopNav.tsx
+++ b/view/components/Navigation/TopNav.tsx
@@ -9,23 +9,23 @@ import {
 } from '@mui/material';
 import { CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { NavigationPaths } from '../../constants/shared.constants';
 import { useIsDesktop } from '../../hooks/shared.hooks';
 import { inDevToast } from '../../utils/shared.utils';
 import LevelOneHeading from '../Shared/LevelOneHeading';
 import Link from '../Shared/Link';
 import TopNavDesktop from './TopNavDesktop';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 interface Props {
   appBarProps?: AppBarProps;
 }
 
 const TopNav = ({ appBarProps }: Props) => {
+  const { pathname } = useLocation();
   const { t } = useTranslation();
   const isDesktop = useIsDesktop();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
   const theme = useTheme();
 
   const appBarStyles: SxProps = {


### PR DESCRIPTION
Ensures clicking the brand link reloads the page if already on the home page.

This is restored functionality from [praxis-ui](https://github.com/praxis-app/praxis-ui).

Merges into: https://github.com/praxis-app/praxis-api/pull/156