### PR TITLE
fix: comment form focus

### DIFF
--- a/view/components/Comments/Comment.tsx
+++ b/view/components/Comments/Comment.tsx
@@ -121,9 +121,9 @@ const Comment = ({
       />
 
       <Box
-        sx={{ backgroundColor: 'background.secondary' }}
-        maxWidth={isDesktop ? 'calc(100% - 90px)' : undefined}
+        bgcolor="background.secondary"
         borderRadius={4}
+        maxWidth={isDesktop ? 'calc(100% - 90px)' : undefined}
         paddingX={1.5}
         paddingY={0.5}
       >

--- a/view/components/Comments/CommentForm.tsx
+++ b/view/components/Comments/CommentForm.tsx
@@ -48,6 +48,7 @@ const CommentForm = ({
   const [images, setImages] = useState<File[]>([]);
   const [imagesInputKey, setImagesInputKey] = useState('');
   const [showForm, setShowForm] = useState(expanded);
+  const [blurCount, setBlurCount] = useState(0);
 
   const [createComment] = useCreateCommentMutation();
   const [updateComment] = useUpdateCommentMutation();
@@ -199,6 +200,13 @@ const CommentForm = ({
     setImagesInputKey(getRandomString());
   };
 
+  const handleInputMount = (input: HTMLInputElement | null) => {
+    if (!input || !enableAutoFocus || blurCount) {
+      return;
+    }
+    input.focus();
+  };
+
   if (!showForm) {
     return (
       <Flex>
@@ -238,17 +246,18 @@ const CommentForm = ({
             <UserAvatar size={35} sx={{ marginRight: 1 }} />
 
             <Box
-              flex={1}
+              bgcolor="background.secondary"
               borderRadius={4}
               paddingX={1.5}
               paddingY={0.2}
-              sx={{ backgroundColor: 'background.secondary' }}
+              flex={1}
             >
               <Input
                 autoComplete="off"
                 name={FieldNames.Body}
                 onChange={handleChange}
-                inputRef={(input) => input && enableAutoFocus && input.focus()}
+                inputRef={handleInputMount}
+                onBlur={() => setBlurCount(blurCount + 1)}
                 onKeyDown={(e) => handleFilledInputKeyDown(e, submitForm)}
                 placeholder={t('comments.prompts.writeComment')}
                 sx={inputStyles}

--- a/view/components/Images/CoverPhoto.tsx
+++ b/view/components/Images/CoverPhoto.tsx
@@ -62,7 +62,7 @@ const CoverPhoto = ({ imageFile, imageId, rounded, topRounded, sx }: Props) => {
   };
 
   if (!getImageSrc()) {
-    return <Box sx={{ backgroundColor: grey[900], ...sharedBoxStyles }} />;
+    return <Box bgcolor={grey[900]} sx={{ ...sharedBoxStyles }} />;
   }
 
   return (


### PR DESCRIPTION
Ensures that the comment form doesn't re-focus after submitting a different form.

The issue would occur when:
- User opens comment form on a post
- User opens post form and submits the post form
- The focus would then be switched back to the comment form

The issue was resolved by disabling auto-focus for the comment form on blur.