### PR TITLE
perf: user home feed

### DIFF
--- a/src/shared/shared.utils.ts
+++ b/src/shared/shared.utils.ts
@@ -4,7 +4,7 @@ import * as sanitizeHtml from 'sanitize-html';
 const logTimeMap: Record<string, number> = {};
 
 /**
- * Log the time similar to `console.time` and `console.timeEnd`,
+ * Log time similar to `console.time` and `console.timeEnd`,
  * but with the ability to save output to a log file
  */
 export const logTime = (label: string, logger: Logger) => {

--- a/src/shared/shared.utils.ts
+++ b/src/shared/shared.utils.ts
@@ -1,5 +1,20 @@
 import * as sanitizeHtml from 'sanitize-html';
 
+const timings: { [key: string]: number } = {};
+
+export const logTime = (identifier: string) => {
+  if (timings[identifier]) {
+    // The timer had already started, mark the time now and subtract the time
+    // of the start to get the duration:
+    const end = performance.now();
+    console.log(`${identifier}: ${Math.round(end - timings[identifier])}ms`);
+
+    delete timings[identifier];
+  } else {
+    timings[identifier] = performance.now();
+  }
+};
+
 /**
  * Strip all HTML tags from a string
  */

--- a/src/shared/shared.utils.ts
+++ b/src/shared/shared.utils.ts
@@ -8,15 +8,16 @@ const logTimeMap: Record<string, number> = {};
  * but with the ability to save output to a log file
  */
 export const logTime = (label: string, logger: Logger) => {
-  if (logTimeMap[label]) {
-    const end = performance.now();
-    const time = Math.round(end - logTimeMap[label]);
-    const message = `${label}: ${time}ms`;
-    logger.log(message);
-    delete logTimeMap[label];
-  } else {
+  if (!logTimeMap[label]) {
     logTimeMap[label] = performance.now();
+    return;
   }
+  const end = performance.now();
+  const time = Math.round(end - logTimeMap[label]);
+  const message = `${label}: ${time}ms`;
+
+  logger.log(message);
+  delete logTimeMap[label];
 };
 
 /**

--- a/src/shared/shared.utils.ts
+++ b/src/shared/shared.utils.ts
@@ -1,13 +1,14 @@
+import { Logger } from '@nestjs/common';
 import * as sanitizeHtml from 'sanitize-html';
 
 const timings: { [key: string]: number } = {};
 
-export const logTime = (identifier: string) => {
+export const logTime = (identifier: string, logger: Logger) => {
   if (timings[identifier]) {
-    // The timer had already started, mark the time now and subtract the time
-    // of the start to get the duration:
     const end = performance.now();
-    console.log(`${identifier}: ${Math.round(end - timings[identifier])}ms`);
+    const message = `${identifier}: ${Math.round(end - timings[identifier])}ms`;
+    console.log(message);
+    logger.log(message);
 
     delete timings[identifier];
   } else {

--- a/src/shared/shared.utils.ts
+++ b/src/shared/shared.utils.ts
@@ -1,17 +1,23 @@
 import { Logger } from '@nestjs/common';
 import * as sanitizeHtml from 'sanitize-html';
 
-const timings: { [key: string]: number } = {};
+const logTimeMap: Record<string, number> = {};
 
+/**
+ * Log the time similar to `console.time` and `console.timeEnd`,
+ * but with the ability to save output to a log file
+ */
 export const logTime = (identifier: string, logger: Logger) => {
-  if (timings[identifier]) {
+  if (logTimeMap[identifier]) {
     const end = performance.now();
-    const message = `${identifier}: ${Math.round(end - timings[identifier])}ms`;
+    const message = `${identifier}: ${Math.round(
+      end - logTimeMap[identifier],
+    )}ms`;
     logger.log(message);
 
-    delete timings[identifier];
+    delete logTimeMap[identifier];
   } else {
-    timings[identifier] = performance.now();
+    logTimeMap[identifier] = performance.now();
   }
 };
 

--- a/src/shared/shared.utils.ts
+++ b/src/shared/shared.utils.ts
@@ -7,17 +7,15 @@ const logTimeMap: Record<string, number> = {};
  * Log the time similar to `console.time` and `console.timeEnd`,
  * but with the ability to save output to a log file
  */
-export const logTime = (identifier: string, logger: Logger) => {
-  if (logTimeMap[identifier]) {
+export const logTime = (label: string, logger: Logger) => {
+  if (logTimeMap[label]) {
     const end = performance.now();
-    const message = `${identifier}: ${Math.round(
-      end - logTimeMap[identifier],
-    )}ms`;
+    const time = Math.round(end - logTimeMap[label]);
+    const message = `${label}: ${time}ms`;
     logger.log(message);
-
-    delete logTimeMap[identifier];
+    delete logTimeMap[label];
   } else {
-    logTimeMap[identifier] = performance.now();
+    logTimeMap[label] = performance.now();
   }
 };
 

--- a/src/shared/shared.utils.ts
+++ b/src/shared/shared.utils.ts
@@ -7,7 +7,6 @@ export const logTime = (identifier: string, logger: Logger) => {
   if (timings[identifier]) {
     const end = performance.now();
     const message = `${identifier}: ${Math.round(end - timings[identifier])}ms`;
-    console.log(message);
     logger.log(message);
 
     delete timings[identifier];

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -60,7 +60,7 @@ export class UsersResolver {
 
   @ResolveField(() => [FeedItem])
   async homeFeed(@Parent() { id }: User) {
-    return this.usersService.getUserHomeFeed(id);
+    return this.usersService.getUserFeed(id);
   }
 
   @ResolveField(() => [FeedItem])

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -78,7 +78,9 @@ export class UsersService {
   }
 
   async getUserHomeFeed(id: number) {
-    logTime('Fetching user home feed');
+    const logTimeMessage = `Fetching user ${id} home feed`;
+    logTime(logTimeMessage, this.logger);
+
     const userFeedQuery = this.repository
       .createQueryBuilder('user')
 
@@ -149,7 +151,7 @@ export class UsersService {
       .where('user.id = :id', { id });
 
     const userFeed = await userFeedQuery.getOne();
-    logTime('Fetching user home feed');
+    logTime(logTimeMessage, this.logger);
 
     if (!userFeed) {
       throw new UserInputError('User not found');

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -78,61 +78,68 @@ export class UsersService {
   }
 
   async getUserHomeFeed(id: number) {
-    logTime('fetching userWithFeed');
+    logTime('Fetching user home feed');
     const userFeedQuery = this.repository
       .createQueryBuilder('user')
+
+      // Posts from followed users
       .leftJoinAndSelect('user.following', 'userFollowing')
       .leftJoinAndSelect('userFollowing.posts', 'followingPost')
 
+      // Posts and proposals from joined groups
       .leftJoinAndSelect('user.groups', 'userGroup')
       .leftJoinAndSelect('userGroup.posts', 'groupPost')
       .leftJoinAndSelect('userGroup.proposals', 'groupProposal')
 
+      // Posts from joined group events
       .leftJoinAndSelect('userGroup.events', 'groupEvent')
       .leftJoinAndSelect('groupEvent.posts', 'groupEventPost')
 
+      // Posts and proposals from this user
       .leftJoinAndSelect('user.proposals', 'userProposal')
       .leftJoinAndSelect('user.posts', 'userPost')
 
-      .select([
-        'user.id',
-        'userGroup.id',
-        'groupEvent.id',
-        'userFollowing.id',
-
+      // Only select required fields
+      .select(['user.id', 'userGroup.id', 'groupEvent.id', 'userFollowing.id'])
+      .addSelect([
         'userPost.id',
         'userPost.groupId',
         'userPost.eventId',
         'userPost.userId',
         'userPost.body',
         'userPost.createdAt',
-
+      ])
+      .addSelect([
         'userProposal.id',
         'userProposal.groupId',
         'userProposal.userId',
         'userProposal.stage',
         'userProposal.body',
         'userProposal.createdAt',
-
+      ])
+      .addSelect([
         'groupPost.id',
         'groupPost.groupId',
         'groupPost.userId',
         'groupPost.body',
         'groupPost.createdAt',
-
+      ])
+      .addSelect([
         'groupProposal.id',
         'groupProposal.groupId',
         'groupProposal.stage',
         'groupProposal.userId',
         'groupProposal.body',
         'groupProposal.createdAt',
-
+      ])
+      .addSelect([
         'groupEventPost.id',
         'groupEventPost.userId',
         'groupEventPost.eventId',
         'groupEventPost.body',
         'groupEventPost.createdAt',
-
+      ])
+      .addSelect([
         'followingPost.id',
         'followingPost.userId',
         'followingPost.eventId',
@@ -140,8 +147,9 @@ export class UsersService {
         'followingPost.createdAt',
       ])
       .where('user.id = :id', { id });
+
     const userFeed = await userFeedQuery.getOne();
-    logTime('fetching userWithFeed');
+    logTime('Fetching user home feed');
 
     if (!userFeed) {
       throw new UserInputError('User not found');

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -78,7 +78,7 @@ export class UsersService {
   }
 
   async getUserHomeFeed(id: number) {
-    const logTimeMessage = `Fetching user ${id} home feed`;
+    const logTimeMessage = `Fetching home feed for user with ID ${id}`;
     logTime(logTimeMessage, this.logger);
 
     const userFeedQuery = this.repository


### PR DESCRIPTION
Improves performance for `getUserHomeFeed` service method.

The `groups.events.posts` relation was found to take up the majority of the time for the query.

Converting to query builder in `getUserHomeFeed` and only selecting required fields cut the time in half. Splitting the home feed query into multiple queries also improved performance.