### PR TITLE
fix: wait until after auth fails to fetch public feed

### DIFF
--- a/view/components/Auth/AuthWrapper.tsx
+++ b/view/components/Auth/AuthWrapper.tsx
@@ -2,7 +2,11 @@
 
 import { ReactNode, useEffect } from 'react';
 import { useAuthCheckQuery } from '../../graphql/auth/queries/gen/AuthCheck.gen';
-import { isAuthLoadingVar, isLoggedInVar } from '../../graphql/cache';
+import {
+  authFailedVar,
+  isAuthLoadingVar,
+  isLoggedInVar,
+} from '../../graphql/cache';
 import TopNav from '../Navigation/TopNav';
 
 interface Props {
@@ -13,6 +17,10 @@ const AuthWrapper = ({ children }: Props) => {
   const { loading } = useAuthCheckQuery({
     onCompleted({ authCheck }) {
       isLoggedInVar(authCheck);
+      authFailedVar(!authCheck);
+    },
+    onError() {
+      authFailedVar(true);
     },
   });
 

--- a/view/components/Groups/PublicGroupsFeed.tsx
+++ b/view/components/Groups/PublicGroupsFeed.tsx
@@ -1,5 +1,7 @@
+import { useReactiveVar } from '@apollo/client';
 import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { authFailedVar } from '../../graphql/cache';
 import { usePublicGroupsFeedQuery } from '../../graphql/groups/queries/gen/PublicGroupsFeed.gen';
 import { isDeniedAccess } from '../../utils/error.utils';
 import WelcomeCard from '../About/WelcomeCard';
@@ -7,8 +9,10 @@ import Feed from '../Shared/Feed';
 import ProgressBar from '../Shared/ProgressBar';
 
 const PublicGroupsFeed = () => {
+  const authFailed = useReactiveVar(authFailedVar);
   const { data, loading, error } = usePublicGroupsFeedQuery({
     errorPolicy: 'all',
+    skip: !authFailed,
   });
 
   const { t } = useTranslation();

--- a/view/components/Navigation/NavDrawer.tsx
+++ b/view/components/Navigation/NavDrawer.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../constants/shared.constants';
 import { useLogOutMutation } from '../../graphql/auth/mutations/gen/LogOut.gen';
 import {
+  authFailedVar,
   inviteTokenVar,
   isAuthLoadingVar,
   isLoggedInVar,
@@ -56,11 +57,12 @@ const ListItemText = styled(MuiListItemText)(({ theme }) => ({
 
 const NavDrawer = () => {
   const isLoggedIn = useReactiveVar(isLoggedInVar);
+  const authFailed = useReactiveVar(authFailedVar);
   const inviteToken = useReactiveVar(inviteTokenVar);
   const open = useReactiveVar(isNavDrawerOpenVar);
 
   const { data: meData } = useMeQuery({ skip: !isLoggedIn });
-  const { data: isFirstUserData } = useIsFirstUserQuery({ skip: isLoggedIn });
+  const { data: isFirstUserData } = useIsFirstUserQuery({ skip: !authFailed });
   const [logOut, { client }] = useLogOutMutation();
 
   const { t } = useTranslation();

--- a/view/components/Navigation/TopNavDesktop.tsx
+++ b/view/components/Navigation/TopNavDesktop.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { NavigationPaths } from '../../constants/shared.constants';
 import {
+  authFailedVar,
   inviteTokenVar,
   isAuthLoadingVar,
   isLoggedInVar,
@@ -41,10 +42,12 @@ const TopNavDesktop = () => {
   const inviteToken = useReactiveVar(inviteTokenVar);
   const isLoggedIn = useReactiveVar(isLoggedInVar);
   const isAuthLoading = useReactiveVar(isAuthLoadingVar);
+  const authFailed = useReactiveVar(authFailedVar);
+
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
 
   const { data: isFirstUserData } = useIsFirstUserQuery({
-    skip: isLoggedIn,
+    skip: !authFailed,
   });
   const { data: meData } = useMeQuery({
     skip: !isLoggedIn,

--- a/view/graphql/cache.ts
+++ b/view/graphql/cache.ts
@@ -15,6 +15,7 @@ export const isNavDrawerOpenVar = makeVar(false);
 // Authentication state
 export const isLoggedInVar = makeVar(false);
 export const isAuthLoadingVar = makeVar(false);
+export const authFailedVar = makeVar(false);
 export const inviteTokenVar = makeVar(getLocalStorageItem(INVITE_TOKEN));
 
 const cache = new InMemoryCache({

--- a/view/pages/App/Home.tsx
+++ b/view/pages/App/Home.tsx
@@ -1,7 +1,7 @@
 import { useReactiveVar } from '@apollo/client';
-import { isLoggedInVar } from '../../graphql/cache';
 import PublicGroupsFeed from '../../components/Groups/PublicGroupsFeed';
 import HomeFeed from '../../components/Users/HomeFeed';
+import { isLoggedInVar } from '../../graphql/cache';
 
 const Home = () => {
   const isLoggedIn = useReactiveVar(isLoggedInVar);


### PR DESCRIPTION
Ensures that `isFirstUser` and `publicGroupsFeed` queries aren't fetched until after auth fails.