### PR TITLE
fix: image lazy loading

### DIFF
--- a/view/components/Events/EventAvatar.tsx
+++ b/view/components/Events/EventAvatar.tsx
@@ -1,4 +1,5 @@
 import { AvatarProps } from '@mui/material';
+import { useRef } from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { EventAvatarFragment } from '../../graphql/events/fragments/gen/EventAvatar.gen';
 import { ProposalActionEventAvatarFragment } from '../../graphql/proposals/fragments/gen/ProposalActionEventAvatar.gen';
@@ -14,7 +15,8 @@ interface Props extends AvatarProps {
 }
 
 const EventAvatar = ({ event, withLink, size, sx, ...avatarProps }: Props) => {
-  const src = useImageSrc(event.coverPhoto?.id);
+  const ref = useRef<HTMLDivElement>(null);
+  const src = useImageSrc(event.coverPhoto?.id, ref);
   const eventPagePath = getEventPath(event.id);
 
   const avatarStyles = {
@@ -26,7 +28,7 @@ const EventAvatar = ({ event, withLink, size, sx, ...avatarProps }: Props) => {
   };
 
   const renderAvatar = () => (
-    <Flex sx={avatarStyles} {...avatarProps}>
+    <Flex ref={ref} sx={avatarStyles} {...avatarProps}>
       <LazyLoadImage
         src={src}
         alt={event.name}

--- a/view/components/Groups/GroupAvatar.tsx
+++ b/view/components/Groups/GroupAvatar.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { GroupAvatarFragment } from '../../graphql/groups/fragments/gen/GroupAvatar.gen';
 import { useImageSrc } from '../../hooks/image.hooks';
@@ -10,12 +11,13 @@ interface Props {
 }
 
 const GroupAvatar = ({ group }: Props) => {
-  const src = useImageSrc(group.coverPhoto?.id);
+  const ref = useRef<HTMLDivElement>(null);
+  const src = useImageSrc(group.coverPhoto?.id, ref);
   const groupPagePath = getGroupPath(group.name);
 
   return (
     <Link href={groupPagePath}>
-      <Flex borderRadius="50%" width={40} height={40}>
+      <Flex ref={ref} borderRadius="50%" width={40} height={40}>
         <LazyLoadImage
           src={src}
           alt={group.name}

--- a/view/components/Images/AttachedImage.tsx
+++ b/view/components/Images/AttachedImage.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { AttachedImageFragment } from '../../graphql/images/fragments/gen/AttachedImage.gen';
 import { useImageSrc } from '../../hooks/image.hooks';
-import { useIsDesktop, useInView } from '../../hooks/shared.hooks';
+import { useIsDesktop } from '../../hooks/shared.hooks';
 
 interface Props {
   image: AttachedImageFragment;
@@ -13,10 +13,8 @@ interface Props {
 
 const AttachedImage = ({ image, marginBottom, width = '100%' }: Props) => {
   const [isLoading, setIsLoaded] = useState(true);
-
   const ref = useRef<HTMLDivElement>(null);
-  const isImageInView = useInView(ref);
-  const src = useImageSrc(image.id, !isImageInView);
+  const src = useImageSrc(image.id, ref);
 
   const isDesktop = useIsDesktop();
   const loadingHeight = isDesktop ? '500px' : '200px';

--- a/view/components/Images/AttachedImage.tsx
+++ b/view/components/Images/AttachedImage.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { Box } from '@mui/material';
+import { useRef, useState } from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { AttachedImageFragment } from '../../graphql/images/fragments/gen/AttachedImage.gen';
 import { useImageSrc } from '../../hooks/image.hooks';
-import { useIsDesktop } from '../../hooks/shared.hooks';
+import { useIsDesktop, useOnScreen } from '../../hooks/shared.hooks';
 
 interface Props {
   image: AttachedImageFragment;
@@ -12,21 +13,26 @@ interface Props {
 
 const AttachedImage = ({ image, marginBottom, width = '100%' }: Props) => {
   const [isLoading, setIsLoaded] = useState(true);
-  const isDesktop = useIsDesktop();
-  const src = useImageSrc(image.id);
 
+  const ref = useRef<HTMLDivElement>(null);
+  const isImageInView = useOnScreen(ref);
+  const src = useImageSrc(image.id, isImageInView);
+
+  const isDesktop = useIsDesktop();
   const loadingHeight = isDesktop ? '500px' : '200px';
 
   return (
-    <LazyLoadImage
-      src={src}
-      effect="blur"
-      width={width}
-      height={isLoading ? loadingHeight : 'auto'}
-      style={{ display: 'block', marginBottom }}
-      onLoad={() => setIsLoaded(false)}
-      alt={image.filename}
-    />
+    <Box ref={ref}>
+      <LazyLoadImage
+        src={src}
+        effect="blur"
+        width={width}
+        height={isLoading ? loadingHeight : 'auto'}
+        style={{ display: 'block', marginBottom }}
+        onLoad={() => setIsLoaded(false)}
+        alt={image.filename}
+      />
+    </Box>
   );
 };
 

--- a/view/components/Images/AttachedImage.tsx
+++ b/view/components/Images/AttachedImage.tsx
@@ -16,7 +16,7 @@ const AttachedImage = ({ image, marginBottom, width = '100%' }: Props) => {
 
   const ref = useRef<HTMLDivElement>(null);
   const isImageInView = useInView(ref);
-  const src = useImageSrc(image.id, isImageInView);
+  const src = useImageSrc(image.id, !isImageInView);
 
   const isDesktop = useIsDesktop();
   const loadingHeight = isDesktop ? '500px' : '200px';

--- a/view/components/Images/AttachedImage.tsx
+++ b/view/components/Images/AttachedImage.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { AttachedImageFragment } from '../../graphql/images/fragments/gen/AttachedImage.gen';
 import { useImageSrc } from '../../hooks/image.hooks';
-import { useIsDesktop, useOnScreen } from '../../hooks/shared.hooks';
+import { useIsDesktop, useInView } from '../../hooks/shared.hooks';
 
 interface Props {
   image: AttachedImageFragment;
@@ -15,7 +15,7 @@ const AttachedImage = ({ image, marginBottom, width = '100%' }: Props) => {
   const [isLoading, setIsLoaded] = useState(true);
 
   const ref = useRef<HTMLDivElement>(null);
-  const isImageInView = useOnScreen(ref);
+  const isImageInView = useInView(ref);
   const src = useImageSrc(image.id, isImageInView);
 
   const isDesktop = useIsDesktop();

--- a/view/components/Images/AttachedImagePreview.tsx
+++ b/view/components/Images/AttachedImagePreview.tsx
@@ -1,5 +1,6 @@
 import { RemoveCircle } from '@mui/icons-material';
 import { Box, IconButton, SxProps } from '@mui/material';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AttachedImageFragment } from '../../graphql/images/fragments/gen/AttachedImage.gen';
 import { useImageSrc } from '../../hooks/image.hooks';
@@ -32,9 +33,10 @@ const SavedImagePreview = ({
   handleDelete?(id: number): void;
   savedImage: AttachedImageFragment;
 }) => {
-  const src = useImageSrc(id);
+  const ref = useRef<HTMLDivElement>(null);
+  const src = useImageSrc(id, ref);
   return (
-    <Box sx={containerStyles}>
+    <Box ref={ref} sx={containerStyles}>
       <img alt={filename} src={src} width="100%" />
       {handleDelete && <RemoveButton onClick={() => handleDelete(id)} />}
     </Box>

--- a/view/components/Images/CoverPhoto.tsx
+++ b/view/components/Images/CoverPhoto.tsx
@@ -1,6 +1,6 @@
 import { Box, SxProps } from '@mui/material';
 import { grey } from '@mui/material/colors';
-import { SyntheticEvent, useState } from 'react';
+import { SyntheticEvent, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { useImageSrc } from '../../hooks/image.hooks';
@@ -30,7 +30,8 @@ const CoverPhoto = ({
 
   const { t } = useTranslation();
   const isDesktop = useIsDesktop();
-  const src = useImageSrc(imageId);
+  const ref = useRef<HTMLDivElement>(null);
+  const src = useImageSrc(imageId, ref);
 
   const getImageSrc = () => {
     if (imageFile) {
@@ -72,7 +73,7 @@ const CoverPhoto = ({
   }
 
   return (
-    <Box sx={{ overflowY: 'hidden', ...sharedBoxStyles }}>
+    <Box ref={ref} sx={{ overflowY: 'hidden', ...sharedBoxStyles }}>
       <LazyLoadImage
         alt={t('images.labels.coverPhoto')}
         effect="blur"

--- a/view/components/Images/CoverPhoto.tsx
+++ b/view/components/Images/CoverPhoto.tsx
@@ -69,7 +69,7 @@ const CoverPhoto = ({
   };
 
   if (!getImageSrc()) {
-    return <Box bgcolor={grey[900]} sx={{ ...sharedBoxStyles }} />;
+    return <Box ref={ref} bgcolor={grey[900]} sx={{ ...sharedBoxStyles }} />;
   }
 
   return (

--- a/view/components/Shared/Flex.tsx
+++ b/view/components/Shared/Flex.tsx
@@ -1,12 +1,15 @@
 import { Box, BoxProps, SxProps } from '@mui/material';
-import { ReactNode, forwardRef } from 'react';
+import { ReactNode, RefObject, forwardRef } from 'react';
 
 export interface FlexProps extends BoxProps {
   children: string | number | ReactNode;
   flexEnd?: boolean;
 }
 
-const Flex = ({ children, flexEnd, sx, ...rest }: FlexProps, ref: any) => {
+const Flex = (
+  { children, flexEnd, sx, ...rest }: FlexProps,
+  ref: RefObject<unknown>,
+) => {
   const styles: SxProps = flexEnd ? { justifyContent: 'flex-end' } : {};
 
   return (

--- a/view/components/Shared/Flex.tsx
+++ b/view/components/Shared/Flex.tsx
@@ -1,19 +1,19 @@
 import { Box, BoxProps, SxProps } from '@mui/material';
-import { ReactNode } from 'react';
+import { ReactNode, forwardRef } from 'react';
 
 export interface FlexProps extends BoxProps {
   children: string | number | ReactNode;
   flexEnd?: boolean;
 }
 
-const Flex = ({ children, flexEnd, sx, ...rest }: FlexProps) => {
+const Flex = ({ children, flexEnd, sx, ...rest }: FlexProps, ref: any) => {
   const styles: SxProps = flexEnd ? { justifyContent: 'flex-end' } : {};
 
   return (
-    <Box sx={{ display: 'flex', ...styles, ...sx }} {...rest}>
+    <Box ref={ref} sx={{ display: 'flex', ...styles, ...sx }} {...rest}>
       {children}
     </Box>
   );
 };
 
-export default Flex;
+export default forwardRef(Flex);

--- a/view/components/Users/UserAvatar.tsx
+++ b/view/components/Users/UserAvatar.tsx
@@ -1,10 +1,11 @@
 import { BoxProps } from '@mui/material';
-import { CSSProperties } from 'react';
+import { CSSProperties, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { UserAvatarFragment } from '../../graphql/users/fragments/gen/UserAvatar.gen';
 import { useMeQuery } from '../../graphql/users/queries/gen/Me.gen';
 import { useImageSrc } from '../../hooks/image.hooks';
+import { useInView } from '../../hooks/shared.hooks';
 import { getUserProfilePath } from '../../utils/user.utils';
 import Flex from '../Shared/Flex';
 import Link from '../Shared/Link';
@@ -27,11 +28,15 @@ const UserAvatar = ({
   ...avatarProps
 }: Props) => {
   const { data } = useMeQuery({ skip: !!user });
+
   const { t } = useTranslation();
+  const ref = useRef<HTMLDivElement>(null);
 
   const me = data && data.me;
   const profilePicture = user?.profilePicture || me?.profilePicture;
-  const src = useImageSrc(profilePicture?.id);
+
+  const isInView = useInView(ref);
+  const src = useImageSrc(profilePicture?.id, isInView);
 
   const userName = user?.name || me?.name;
   const userProfilePath = getUserProfilePath(userName);

--- a/view/components/Users/UserAvatar.tsx
+++ b/view/components/Users/UserAvatar.tsx
@@ -58,7 +58,7 @@ const UserAvatar = ({
 
   const renderAvatar = () => {
     return (
-      <Flex sx={avatarStyles} {...avatarProps}>
+      <Flex ref={ref} sx={avatarStyles} {...avatarProps}>
         <LazyLoadImage
           src={getAvatarSrc()}
           alt={t('images.labels.profilePicture')}

--- a/view/components/Users/UserAvatar.tsx
+++ b/view/components/Users/UserAvatar.tsx
@@ -5,7 +5,6 @@ import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { UserAvatarFragment } from '../../graphql/users/fragments/gen/UserAvatar.gen';
 import { useMeQuery } from '../../graphql/users/queries/gen/Me.gen';
 import { useImageSrc } from '../../hooks/image.hooks';
-import { useInView } from '../../hooks/shared.hooks';
 import { getUserProfilePath } from '../../utils/user.utils';
 import Flex from '../Shared/Flex';
 import Link from '../Shared/Link';
@@ -34,9 +33,7 @@ const UserAvatar = ({
 
   const me = data && data.me;
   const profilePicture = user?.profilePicture || me?.profilePicture;
-
-  const isInView = useInView(ref);
-  const src = useImageSrc(profilePicture?.id, !isInView);
+  const src = useImageSrc(profilePicture?.id, ref);
 
   const userName = user?.name || me?.name;
   const userProfilePath = getUserProfilePath(userName);

--- a/view/components/Users/UserAvatar.tsx
+++ b/view/components/Users/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import { BoxProps } from '@mui/material';
+import { BoxProps, useTheme } from '@mui/material';
 import { CSSProperties, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
@@ -30,6 +30,7 @@ const UserAvatar = ({
 
   const { t } = useTranslation();
   const ref = useRef<HTMLDivElement>(null);
+  const theme = useTheme();
 
   const me = data && data.me;
   const profilePicture = user?.profilePicture || me?.profilePicture;
@@ -39,6 +40,7 @@ const UserAvatar = ({
   const userProfilePath = getUserProfilePath(userName);
 
   const avatarStyles = {
+    backgroundColor: theme.palette.background.paper,
     borderRadius: '50%',
     width: 40,
     height: 40,

--- a/view/components/Users/UserAvatar.tsx
+++ b/view/components/Users/UserAvatar.tsx
@@ -36,7 +36,7 @@ const UserAvatar = ({
   const profilePicture = user?.profilePicture || me?.profilePicture;
 
   const isInView = useInView(ref);
-  const src = useImageSrc(profilePicture?.id, isInView);
+  const src = useImageSrc(profilePicture?.id, !isInView);
 
   const userName = user?.name || me?.name;
   const userProfilePath = getUserProfilePath(userName);

--- a/view/components/Users/UserProfileCard.tsx
+++ b/view/components/Users/UserProfileCard.tsx
@@ -87,6 +87,7 @@ const UserProfileCard = ({ user, ...cardProps }: Props) => {
     marginBottom: 1.25,
     marginLeft: -0.25,
     marginTop: isDesktop ? -10.5 : -7,
+    zIndex: 1,
   };
 
   return (

--- a/view/hooks/image.hooks.ts
+++ b/view/hooks/image.hooks.ts
@@ -1,13 +1,18 @@
-import { useEffect, useState } from 'react';
+import { RefObject, useEffect, useState } from 'react';
 import { API_ROOT } from '../constants/shared.constants';
 import { getAuthHeader } from '../graphql/client';
+import { useInView } from './shared.hooks';
 
 // TODO: Extract getImageSrc as a utility function
-export const useImageSrc = (imageId: number | undefined, skip = false) => {
+export const useImageSrc = (
+  imageId: number | undefined,
+  ref: RefObject<HTMLElement>,
+) => {
   const [src, setSrc] = useState<string>();
+  const isInView = useInView(ref);
 
   useEffect(() => {
-    if (!imageId || skip) {
+    if (!imageId || !isInView) {
       return;
     }
     const getImageSrc = async () => {
@@ -20,7 +25,7 @@ export const useImageSrc = (imageId: number | undefined, skip = false) => {
       setSrc(url);
     };
     getImageSrc();
-  }, [imageId, skip]);
+  }, [imageId, isInView]);
 
   return src;
 };

--- a/view/hooks/image.hooks.ts
+++ b/view/hooks/image.hooks.ts
@@ -3,16 +3,15 @@ import { API_ROOT } from '../constants/shared.constants';
 import { getAuthHeader } from '../graphql/client';
 import { useInView } from './shared.hooks';
 
-// TODO: Extract getImageSrc as a utility function
 export const useImageSrc = (
   imageId: number | undefined,
   ref: RefObject<HTMLElement>,
 ) => {
   const [src, setSrc] = useState<string>();
-  const isInView = useInView(ref);
+  const [, viewed] = useInView(ref);
 
   useEffect(() => {
-    if (!imageId || !isInView) {
+    if (!imageId || !viewed) {
       return;
     }
     const getImageSrc = async () => {
@@ -25,7 +24,7 @@ export const useImageSrc = (
       setSrc(url);
     };
     getImageSrc();
-  }, [imageId, isInView]);
+  }, [imageId, viewed]);
 
   return src;
 };

--- a/view/hooks/image.hooks.ts
+++ b/view/hooks/image.hooks.ts
@@ -3,11 +3,11 @@ import { API_ROOT } from '../constants/shared.constants';
 import { getAuthHeader } from '../graphql/client';
 
 // TODO: Extract getImageSrc as a utility function
-export const useImageSrc = (imageId: number | undefined) => {
+export const useImageSrc = (imageId: number | undefined, skip = false) => {
   const [src, setSrc] = useState<string>();
 
   useEffect(() => {
-    if (!imageId) {
+    if (!imageId || skip) {
       return;
     }
     const getImageSrc = async () => {
@@ -20,7 +20,7 @@ export const useImageSrc = (imageId: number | undefined) => {
       setSrc(url);
     };
     getImageSrc();
-  }, [imageId]);
+  }, [imageId, skip]);
 
   return src;
 };

--- a/view/hooks/shared.hooks.ts
+++ b/view/hooks/shared.hooks.ts
@@ -29,11 +29,13 @@ export const useScrollPosition = () => {
 
 export const useInView = (ref: RefObject<HTMLElement>, rootMargin = '0px') => {
   const [inView, setInView] = useState(false);
+  const [viewed, setViewed] = useState(false);
 
   useEffect(() => {
     const isBrowserCompatible = 'IntersectionObserver' in window;
     if (!isBrowserCompatible) {
       setInView(true);
+      setViewed(true);
       return;
     }
     if (!ref.current) {
@@ -41,7 +43,12 @@ export const useInView = (ref: RefObject<HTMLElement>, rootMargin = '0px') => {
     }
 
     const observer = new IntersectionObserver(
-      ([entry]) => setInView(entry.isIntersecting),
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setViewed(true);
+        }
+        setInView(entry.isIntersecting);
+      },
       { rootMargin },
     );
     observer.observe(ref.current);
@@ -51,5 +58,5 @@ export const useInView = (ref: RefObject<HTMLElement>, rootMargin = '0px') => {
     };
   }, [ref, rootMargin]);
 
-  return inView;
+  return [inView, viewed];
 };

--- a/view/hooks/shared.hooks.ts
+++ b/view/hooks/shared.hooks.ts
@@ -1,5 +1,5 @@
 import { Breakpoint, useMediaQuery, useTheme } from '@mui/material';
-import { RefObject, useEffect, useMemo, useState } from 'react';
+import { RefObject, useEffect, useState } from 'react';
 import { BrowserEvents } from '../constants/shared.constants';
 
 export const useAboveBreakpoint = (breakpoint: Breakpoint) =>
@@ -27,24 +27,25 @@ export const useScrollPosition = () => {
   return scrollPosition;
 };
 
-export const useInView = (ref: RefObject<HTMLElement>) => {
-  const [isIntersecting, setIntersecting] = useState(false);
-
-  const observer = useMemo(
-    () =>
-      new IntersectionObserver(([entry]) =>
-        setIntersecting(entry.isIntersecting),
-      ),
-    [],
-  );
+export const useInView = (ref: RefObject<HTMLElement>, rootMargin = '0px') => {
+  const [inView, setInView] = useState(false);
 
   useEffect(() => {
-    if (!ref.current) {
+    const isBrowserCompatible = 'IntersectionObserver' in window;
+    if (!ref.current || !isBrowserCompatible) {
       return;
     }
-    observer.observe(ref.current);
-    return () => observer.disconnect();
-  }, [ref, observer]);
 
-  return isIntersecting;
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      { rootMargin },
+    );
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, rootMargin]);
+
+  return inView;
 };

--- a/view/hooks/shared.hooks.ts
+++ b/view/hooks/shared.hooks.ts
@@ -32,7 +32,11 @@ export const useInView = (ref: RefObject<HTMLElement>, rootMargin = '0px') => {
 
   useEffect(() => {
     const isBrowserCompatible = 'IntersectionObserver' in window;
-    if (!ref.current || !isBrowserCompatible) {
+    if (!isBrowserCompatible) {
+      setInView(true);
+      return;
+    }
+    if (!ref.current) {
       return;
     }
 

--- a/view/hooks/shared.hooks.ts
+++ b/view/hooks/shared.hooks.ts
@@ -27,7 +27,7 @@ export const useScrollPosition = () => {
   return scrollPosition;
 };
 
-export const useOnScreen = (ref: RefObject<HTMLElement>) => {
+export const useInView = (ref: RefObject<HTMLElement>) => {
   const [isIntersecting, setIntersecting] = useState(false);
 
   const observer = useMemo(

--- a/view/hooks/shared.hooks.ts
+++ b/view/hooks/shared.hooks.ts
@@ -1,5 +1,5 @@
 import { Breakpoint, useMediaQuery, useTheme } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { RefObject, useEffect, useMemo, useState } from 'react';
 import { BrowserEvents } from '../constants/shared.constants';
 
 export const useAboveBreakpoint = (breakpoint: Breakpoint) =>
@@ -25,4 +25,26 @@ export const useScrollPosition = () => {
   }, []);
 
   return scrollPosition;
+};
+
+export const useOnScreen = (ref: RefObject<HTMLElement>) => {
+  const [isIntersecting, setIntersecting] = useState(false);
+
+  const observer = useMemo(
+    () =>
+      new IntersectionObserver(([entry]) =>
+        setIntersecting(entry.isIntersecting),
+      ),
+    [],
+  );
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, observer]);
+
+  return isIntersecting;
 };


### PR DESCRIPTION
Recent changes made to secure images disrupted lazy loading for images. This change ensures that requests for images aren't made until image element is in view.