### PR TITLE
fix: role update clearing role name

### DIFF
--- a/src/groups/group-roles/group-roles.service.ts
+++ b/src/groups/group-roles/group-roles.service.ts
@@ -81,8 +81,8 @@ export class GroupRolesService {
     { name, ...roleData }: DeepPartial<GroupRole>,
     fromProposalAction = false,
   ) {
-    const santizedName = sanitizeText(name);
-    if (name && santizedName.length > 25) {
+    const sanitizedName = sanitizeText(name);
+    if (name && sanitizedName.length > 25) {
       throw new Error('Role name cannot be longer than 25 characters');
     }
     if (fromProposalAction) {
@@ -91,7 +91,7 @@ export class GroupRolesService {
     }
     const permission = initGroupRolePermissions();
     const groupRole = await this.groupRoleRepository.save({
-      name: santizedName,
+      name: sanitizedName,
       permission,
       ...roleData,
     });
@@ -105,8 +105,8 @@ export class GroupRolesService {
     permissions,
     ...roleData
   }: UpdateGroupRoleInput) {
-    const santizedName = sanitizeText(name);
-    if (name && santizedName.length > 25) {
+    const sanitizedName = sanitizeText(name);
+    if (name && sanitizedName.length > 25) {
       throw new Error('Role name cannot be longer than 25 characters');
     }
     const roleWithRelations = await this.getGroupRole({ id }, [
@@ -121,7 +121,7 @@ export class GroupRolesService {
     const groupRole = await this.groupRoleRepository.save({
       ...roleWithRelations,
       ...roleData,
-      name: santizedName,
+      name: sanitizedName,
       members: [...roleWithRelations.members, ...newMembers],
       permission: { ...roleWithRelations.permission, ...cleanedPermissions },
     });

--- a/src/groups/group-roles/group-roles.service.ts
+++ b/src/groups/group-roles/group-roles.service.ts
@@ -106,8 +106,8 @@ export class GroupRolesService {
     ...roleData
   }: UpdateGroupRoleInput) {
     const sanitizedName = sanitizeText(name);
-    if (name && sanitizedName.length > 25) {
-      throw new Error('Role name cannot be longer than 25 characters');
+    if (typeof name === 'string' && !sanitizedName) {
+      throw new Error('Role name is required');
     }
     if (name && sanitizedName.length > 25) {
       throw new Error('Role name cannot be longer than 25 characters');

--- a/src/groups/group-roles/group-roles.service.ts
+++ b/src/groups/group-roles/group-roles.service.ts
@@ -109,6 +109,9 @@ export class GroupRolesService {
     if (name && sanitizedName.length > 25) {
       throw new Error('Role name cannot be longer than 25 characters');
     }
+    if (name && sanitizedName.length > 25) {
+      throw new Error('Role name cannot be longer than 25 characters');
+    }
     const roleWithRelations = await this.getGroupRole({ id }, [
       'members',
       'permission',
@@ -121,7 +124,7 @@ export class GroupRolesService {
     const groupRole = await this.groupRoleRepository.save({
       ...roleWithRelations,
       ...roleData,
-      name: sanitizedName,
+      name: sanitizedName || roleWithRelations.name,
       members: [...roleWithRelations.members, ...newMembers],
       permission: { ...roleWithRelations.permission, ...cleanedPermissions },
     });

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -276,17 +276,17 @@ export class GroupsService {
     { name, description, coverPhoto, ...groupData }: CreateGroupInput,
     userId: number,
   ) {
-    const santizedName = sanitizeText(name);
+    const sanitizedName = sanitizeText(name);
     const sanitizedDescription = sanitizeText(description);
     const isValidName = VALID_NAME_REGEX.test(name || '');
 
     if (!isValidName) {
       throw new Error('Group names cannot contain special characters');
     }
-    if (santizedName.length < 5) {
+    if (sanitizedName.length < 5) {
       throw new Error('Group name must be at least 5 characters');
     }
-    if (santizedName.length > 25) {
+    if (sanitizedName.length > 25) {
       throw new Error('Group name cannot exceed 25 characters');
     }
     if (sanitizedDescription.length > 1000) {
@@ -295,7 +295,7 @@ export class GroupsService {
 
     const group = await this.groupRepository.save({
       description: sanitizedDescription,
-      name: santizedName,
+      name: sanitizedName,
       ...groupData,
     });
     await this.createGroupMember(group.id, userId);
@@ -319,7 +319,7 @@ export class GroupsService {
     coverPhoto,
     ...groupData
   }: UpdateGroupInput) {
-    const santizedName = sanitizeText(name);
+    const sanitizedName = sanitizeText(name);
     const sanitizedDescription = sanitizeText(description);
     const isValidName = VALID_NAME_REGEX.test(name || '');
 
@@ -329,10 +329,10 @@ export class GroupsService {
     if (!isValidName) {
       throw new Error('Group names cannot contain special characters');
     }
-    if (name && santizedName.length < 5) {
+    if (name && sanitizedName.length < 5) {
       throw new Error('Group name must be at least 5 characters');
     }
-    if (name && santizedName.length > 25) {
+    if (name && sanitizedName.length > 25) {
       throw new Error('Group name cannot exceed 25 characters');
     }
     if (description && sanitizedDescription.length > 1000) {
@@ -341,7 +341,7 @@ export class GroupsService {
 
     await this.groupRepository.update(id, {
       description: sanitizedDescription,
-      name: santizedName,
+      name: sanitizedName,
       ...groupData,
     });
 

--- a/src/server-roles/server-roles.service.ts
+++ b/src/server-roles/server-roles.service.ts
@@ -73,11 +73,11 @@ export class ServerRolesService {
     { name, ...roleData }: DeepPartial<ServerRole>,
     fromProposalAction = false,
   ) {
-    const santizedName = sanitizeText(name);
-    if (!santizedName) {
+    const sanitizedName = sanitizeText(name);
+    if (!sanitizedName) {
       throw new Error('Role name is required');
     }
-    if (santizedName.length > 25) {
+    if (sanitizedName.length > 25) {
       throw new Error('Role name cannot be longer than 25 characters');
     }
     if (fromProposalAction) {
@@ -85,7 +85,7 @@ export class ServerRolesService {
     }
     const permission = initServerRolePermissions();
     const serverRole = await this.serverRoleRepository.save({
-      name: santizedName,
+      name: sanitizedName,
       permission,
       ...roleData,
     });
@@ -102,11 +102,11 @@ export class ServerRolesService {
     }: UpdateServerRoleInput,
     me: User,
   ) {
-    const santizedName = sanitizeText(name);
-    if (typeof name === 'string' && !santizedName) {
+    const sanitizedName = sanitizeText(name);
+    if (typeof name === 'string' && !sanitizedName) {
       throw new Error('Role name is required');
     }
-    if (name && santizedName.length > 25) {
+    if (name && sanitizedName.length > 25) {
       throw new Error('Role name cannot be longer than 25 characters');
     }
     const roleWithRelations = await this.getServerRole({ id }, [
@@ -117,15 +117,16 @@ export class ServerRolesService {
       where: { id: In(selectedUserIds), verified: true },
     });
 
-    const serverRole = await this.serverRoleRepository.save({
+    await this.serverRoleRepository.save({
       ...roleWithRelations,
       ...roleData,
-      name: santizedName,
+      name: sanitizedName || undefined,
       members: [...roleWithRelations.members, ...newMembers],
       permission: { ...roleWithRelations.permission, ...permissions },
     });
     await this.chatService.syncVibeChatMembersWithRoles();
 
+    const serverRole = await this.getServerRole({ id });
     return { serverRole, me };
   }
 

--- a/src/server-roles/server-roles.service.ts
+++ b/src/server-roles/server-roles.service.ts
@@ -117,16 +117,15 @@ export class ServerRolesService {
       where: { id: In(selectedUserIds), verified: true },
     });
 
-    await this.serverRoleRepository.save({
+    const serverRole = await this.serverRoleRepository.save({
       ...roleWithRelations,
       ...roleData,
-      name: sanitizedName || undefined,
+      name: sanitizedName || roleWithRelations.name,
       members: [...roleWithRelations.members, ...newMembers],
       permission: { ...roleWithRelations.permission, ...permissions },
     });
     await this.chatService.syncVibeChatMembersWithRoles();
 
-    const serverRole = await this.getServerRole({ id });
     return { serverRole, me };
   }
 


### PR DESCRIPTION
When updating role permissions, the name would get wiped.